### PR TITLE
Add support for additional test frameworks as picklist

### DIFF
--- a/PublishTestPlanResultsV1/TaskParameters.ts
+++ b/PublishTestPlanResultsV1/TaskParameters.ts
@@ -52,7 +52,7 @@ export function getFrameworkParameters(): TestFrameworkParameters {
       return true;
     });
 
-  return new TestFrameworkParameters(testResultFiles, testResultFormat as string);
+  return new TestFrameworkParameters(testResultFiles, testResultFormat!.toLowerCase()); 
 }
 
 export function getProcessorParameters() : TestResultProcessorParameters {

--- a/PublishTestPlanResultsV1/framework/TestFrameworkFormat.ts
+++ b/PublishTestPlanResultsV1/framework/TestFrameworkFormat.ts
@@ -1,4 +1,9 @@
 export enum TestFrameworkFormat {
-  xUnit = "xunit",
-  jUnit = "junit"
+  xunit = "xunit",
+  junit = "junit",
+  cucumber = "cucumber",
+  mocha = "mocha",
+  nunit = "nunit",
+  testng = "testng"
+  //mstest = "mstest"
 }

--- a/PublishTestPlanResultsV1/framework/TestFrameworkParameters.ts
+++ b/PublishTestPlanResultsV1/framework/TestFrameworkParameters.ts
@@ -8,5 +8,11 @@ export class TestFrameworkParameters {
   constructor(files: string[], format: string) {
     this.testFiles = files;
     this.testFormat = TestFrameworkFormat[format as keyof typeof TestFrameworkFormat];
+
+    if (this.testFormat === undefined) {
+      let keys : string[] = Object.keys(TestFrameworkFormat);
+
+      throw new Error(`testResultformat '${format}' is not supported. Please specify one of the following values: ${ keys.join(', ')}`);
+    }
   }
 }

--- a/PublishTestPlanResultsV1/package-lock.json
+++ b/PublishTestPlanResultsV1/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "azure-devops-node-api": "^12.1.0",
         "azure-pipelines-task-lib": "^4.6.1",
-        "test-results-parser": "^0.1.5"
+        "test-results-parser": "^0.1.6"
       },
       "devDependencies": {
         "@types/chai": "^4.3.11",

--- a/PublishTestPlanResultsV1/package.json
+++ b/PublishTestPlanResultsV1/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "azure-devops-node-api": "^12.1.0",
     "azure-pipelines-task-lib": "^4.6.1",
-    "test-results-parser": "^0.1.5"
+    "test-results-parser": "^0.1.6"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",

--- a/PublishTestPlanResultsV1/task.json
+++ b/PublishTestPlanResultsV1/task.json
@@ -87,15 +87,19 @@
         },
         {
             "name": "testResultFormat",
-            "type": "string",
+            "type": "pickList",
             "label": "Test Result Format",
             "required": true,
             "groupName": "general",
             "options": {
                 "xUnit": "xUnit",
-                "jUnit": "jUnit"
+                "jUnit": "jUnit",
+                "cucumber": "cucumber",
+                "nUnit": "nUnit",
+                "testng": "testng",
+                "mocha": "mocha"
             },
-            "helpMarkDown": "Represents which compatible framework the test results are formatted in. (Currently JUnit, XUnit, but other formats are planned)"
+            "helpMarkDown": "Represents which compatible framework the test results are formatted in. (JUnit, XUnit, TestNG, Mocha, Cucumber, etc)"
         },
         {
             "name": "testResultDirectory",

--- a/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
+++ b/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
@@ -192,6 +192,30 @@ describe('TaskParameters', () => {
       expect(parameters.testFiles[1]).to.eq(validFiles[1]);
     });
 
+    it('Should complain if testResultFormat is not a supported type.', () => {
+      // arrange
+      util.setInput("testResultFormat","yomamma");
+      util.setInput("testResultFiles", validFiles.join(","));
+      util.loadData();
+
+      // act / assert
+      util.shouldThrow( () => TaskParameters.getFrameworkParameters(), /testResultformat 'yomamma' is not supported. Please specify one of the following values: xunit, .*/);
+    })
+
+    it('Should allow mixed case on testResultFormat', () => {
+      // arrange
+      util.setInput("testResultFormat","XuNiT");
+      util.setInput("testResultFiles", validFiles.join(","));
+      util.loadData();
+      
+      // act
+      require(tp);
+      var parameters = TaskParameters.getFrameworkParameters();
+
+      // assert
+      expect(parameters.testFormat).to.eq("xunit");
+    })
+
   });
 
   context('TestResultProcessorParameters', () => {

--- a/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
@@ -5,34 +5,105 @@ import * as TestFrameworkResultReader from '../framework/TestFrameworkResultRead
 
 describe("TestFramework Results Reader", () => {
 
-  context("xUnit", () => {
+  var baseDir : string;
 
-    var baseDir : string;
+  before(() => {
+    baseDir = path.join(__dirname, "data");
+  })
 
-    before(() => {
-      baseDir = path.join(__dirname, "data");
-    })
+  it("Can read xUnit results", async () => {
+    // arrange
+    var files = [];
+    files.push(path.join(baseDir, "xunit", "xunit-1.xml"));
+    var parameters = new TestFrameworkParameters(files, "xunit");
+    
+    // act
+    var results = await TestFrameworkResultReader.readResults(parameters);
 
-    it("Can read xUnit results", async () => {
-      // arrange
-      var files = [];
-      files.push(path.join(baseDir, "xunit", "xunit-1.xml"));
-      var parameters = new TestFrameworkParameters(files, "xUnit");
-      
-      // act
-      var results = await TestFrameworkResultReader.readResults(parameters);
+    // assert
+    expect(results.length).to.eq(1);
+  });
+ 
+ 
+  it("Can read jUnit results", async () => {
+    // arrange
+    var files = [];
+    files.push(path.join(baseDir, "junit", "single-suite.xml"));
+    var parameters = new TestFrameworkParameters(files, "junit");
+    
+    // act
+    var results = await TestFrameworkResultReader.readResults(parameters);
 
-      // assert
-      expect(results.length).to.eq(1);
-    });
-
+    // assert
+    expect(results.length).to.eq(1);
   });
 
-  // context("jUnit", () => {
+  it("Can read Cucumber results", async () => {
+    // arrange
+    var files = [];
+    files.push(path.join(baseDir, "cucumber", "single-suite-single-test.json"));
+    var parameters = new TestFrameworkParameters(files, "cucumber");
+    
+    // act
+    var results = await TestFrameworkResultReader.readResults(parameters);
 
-  //   it("Can read jUnit results", () => {
-  //     throw new Error("Not implemented");
-  //   });
+    // assert
+    expect(results.length).to.eq(1);
+  });
 
-  // })
+  it("Can read Mocha results", async () => {
+    // arrange
+    var files = [];
+    files.push(path.join(baseDir, "mocha", "single-suite-single-test.json"));
+    var parameters = new TestFrameworkParameters(files, "mocha");
+    
+    // act
+    var results = await TestFrameworkResultReader.readResults(parameters);
+
+    // assert
+    expect(results.length).to.eq(1);
+  });
+
+  it("Can read NUnit results", async () => {
+    // arrange
+    var files = [];
+    files.push(path.join(baseDir, "nunit", "nunit_v3.xml"));
+    var parameters = new TestFrameworkParameters(files, "nunit");
+    
+    // act
+    var results = await TestFrameworkResultReader.readResults(parameters);
+
+    // assert
+    expect(results.length).to.be.greaterThan(0);
+  });
+
+  it("Can read TestNG results", async () => {
+    // arrange
+    var files = [];
+    files.push(path.join(baseDir, "testng", "single-suite.xml"));
+    var parameters = new TestFrameworkParameters(files, "testng");
+    
+    // act
+    var results = await TestFrameworkResultReader.readResults(parameters);
+
+    // assert
+    expect(results.length).to.be.greaterThan(1);
+  });
+
+
+  // waiting for 0.1.7 that includes this
+  // it("Can read MStests results", async () => {
+  //   // arrange
+  //   var files = [];
+  //   files.push(path.join(baseDir, "mstest", "testresults.trx"));
+  //   var parameters = new TestFrameworkParameters(files, "mstest");
+    
+  //   // act
+  //   var results = await TestFrameworkResultReader.readResults(parameters);
+
+  //   // assert
+  //   expect(results.length).to.eq(1);
+  // });
+
+
 })

--- a/PublishTestPlanResultsV1/test/data/cucumber/single-suite-single-test.json
+++ b/PublishTestPlanResultsV1/test/data/cucumber/single-suite-single-test.json
@@ -1,0 +1,89 @@
+[
+  {
+    "description": "Verify calculator functionalities",
+    "elements": [
+      {
+        "description": "",
+        "id": "addition;addition-of-two-numbers",
+        "keyword": "Scenario",
+        "line": 5,
+        "name": "Addition of two numbers",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 6,
+            "name": "I have number 6 in calculator",
+            "match": {
+              "location": "features\\support\\steps.js:5"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 1211400
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "When ",
+            "line": 7,
+            "name": "I entered number 7",
+            "match": {
+              "location": "features\\support\\steps.js:9"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 136500
+            }
+          },
+          {
+            "arguments": [],
+            "keyword": "Then ",
+            "line": 8,
+            "name": "I should see result 13",
+            "match": {
+              "location": "features\\support\\steps.js:13"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 244700
+            }
+          }
+        ],
+        "tags": [
+          {
+            "name": "@green",
+            "line": 4
+          },
+          {
+            "name": "@fast",
+            "line": 4
+          },
+          {
+            "name": "@testCase=1234",
+            "line": 4
+          }
+        ],
+        "type": "scenario"
+      }
+    ],
+    "id": "addition",
+    "line": 1,
+    "keyword": "Feature",
+    "name": "Addition",
+    "tags": [
+      {
+        "name": "@blue",
+        "line": 4
+      },
+      {
+        "name": "@slow",
+        "line": 4
+      },
+      {
+        "name": "@suite=1234",
+        "line": 4
+      }
+    ],
+    "uri": "features\\sample.feature"
+  }
+]

--- a/PublishTestPlanResultsV1/test/data/junit/single-suite.xml
+++ b/PublishTestPlanResultsV1/test/data/junit/single-suite.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+<testsuites id="id" name="result name" tests="1" failures="1" errors="" time="10">
+    <testsuite id="codereview.cobol.analysisProvider" name="suite name" tests="1" failures="1" time="10">
+        <testcase id="codereview.cobol.rules.ProgramIdRule" name="Use a program name that matches the source file name" time="10">
+            <failure message="PROGRAM.cbl:2 Use a program name that matches the source file name" type="WARNING">
+                Some Text
+            </failure>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/PublishTestPlanResultsV1/test/data/mocha/single-suite-single-test.json
+++ b/PublishTestPlanResultsV1/test/data/mocha/single-suite-single-test.json
@@ -1,0 +1,36 @@
+{
+  "stats": {
+    "suites": 1,
+    "tests": 1,
+    "passes": 1,
+    "pending": 0,
+    "failures": 0,
+    "start": "2022-06-11T05:24:09.223Z",
+    "end": "2022-06-11T05:24:09.226Z",
+    "duration": 3
+  },
+  "tests": [
+    {
+      "title": "Simple suite test",
+      "fullTitle": "Simple Suite Simple suite test",
+      "file": "D:\\tests\\test.mocha.spec.js",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    }
+  ],
+  "pending": [],
+  "failures": [],
+  "passes": [
+    {
+      "title": "Simple suite test",
+      "fullTitle": "Simple Suite Simple suite test",
+      "file": "D:\\tests\\test.mocha.spec.js",
+      "duration": 1,
+      "currentRetry": 0,
+      "speed": "fast",
+      "err": {}
+    }
+  ]
+}

--- a/PublishTestPlanResultsV1/test/data/mstest/testresults.trx
+++ b/PublishTestPlanResultsV1/test/data/mstest/testresults.trx
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestRun id="413d0867-f074-4fe6-ab37-b766b82cd97c" name="bryan.b.cook@MYCOMPUTER 2023-11-12 19:21:51" runUser="DOMAIN\bryan.b.cook"
+    xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+    <Times creation="2023-11-12T19:21:51.7813392-05:00" queuing="2023-11-12T19:21:51.7813396-05:00" start="2023-11-12T19:21:50.8694867-05:00" finish="2023-11-12T19:21:51.8154544-05:00" />
+    <TestSettings name="default" id="155de8f5-30de-41da-bf8d-1c03eb63e978">
+        <Deployment runDeploymentRoot="bryan.b.cook_MYCOMPUTER_2023-11-12_19_21_51" />
+    </TestSettings>
+    <Results>
+        <UnitTestResult executionId="e01a54d8-305c-4828-9bc0-8c935270dafe" testId="5370a586-74b0-a647-4839-100eef3a4188" testName="FailingTest" computerName="MYCOMPUTER" duration="00:00:00.0259239" startTime="2023-11-12T19:21:51.6583003-05:00" endTime="2023-11-12T19:21:51.6978162-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e01a54d8-305c-4828-9bc0-8c935270dafe">
+            <Output>
+                <ErrorInfo>
+                    <Message>Assert.Fail failed. </Message>
+                    <StackTrace>   at MSTestSample.MockTestFixture.FailingTest() in C:\dev\code\_Experiments\MSTestSample\UnitTest1.cs:line 12&#xD;
+                    </StackTrace>
+                </ErrorInfo>
+            </Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="9915e227-fac8-4f88-b86c-a456bc7031a3" testId="2edb0741-aaff-135c-69bb-02a2e6d737cd" testName="InconclusiveTest" computerName="MYCOMPUTER" duration="00:00:00.0006505" startTime="2023-11-12T19:21:51.7029151-05:00" endTime="2023-11-12T19:21:51.7036802-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9915e227-fac8-4f88-b86c-a456bc7031a3">
+            <Output>
+                <ErrorInfo>
+                    <Message>Assert.Inconclusive failed. </Message>
+                    <StackTrace>   at MSTestSample.MockTestFixture.InconclusiveTest() in C:\dev\code\_Experiments\MSTestSample\UnitTest1.cs:line 19&#xD;
+                    </StackTrace>
+                </ErrorInfo>
+            </Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="a02c1a7d-98d2-4829-aacf-b818d4fd6e3e" testId="8ed1bf6e-f1d2-7450-caab-53e4f5a4dd2c" testName="MockTest1" computerName="MYCOMPUTER" duration="00:00:00.0000387" startTime="2023-11-12T19:21:51.7037282-05:00" endTime="2023-11-12T19:21:51.7038253-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a02c1a7d-98d2-4829-aacf-b818d4fd6e3e" />
+        <UnitTestResult executionId="01f88d1f-7d8d-402d-9c18-bf81649b3296" testId="9475a122-272d-f5ef-87e4-fe7d1a7f0418" testName="MockTest2" computerName="MYCOMPUTER" duration="00:00:00.0000219" startTime="2023-11-12T19:21:51.7038450-05:00" endTime="2023-11-12T19:21:51.7039074-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="01f88d1f-7d8d-402d-9c18-bf81649b3296" />
+        <UnitTestResult executionId="4db5da11-faef-4e70-98d1-39ee00d6ed00" testId="6b0e8fc2-5324-dbeb-0c5f-0479cd14f351" testName="MockTest3" computerName="MYCOMPUTER" duration="00:00:00.0000196" startTime="2023-11-12T19:21:51.7039180-05:00" endTime="2023-11-12T19:21:51.7039706-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4db5da11-faef-4e70-98d1-39ee00d6ed00" />
+        <UnitTestResult executionId="68e29212-0297-4843-8f1e-cad3dfe2dd06" testId="0b5c3ebb-3086-951a-1724-1821d30aef04" testName="MockTest4" computerName="MYCOMPUTER" startTime="2023-11-12T19:21:51.7039815-05:00" endTime="2023-11-12T19:21:51.7041817-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="68e29212-0297-4843-8f1e-cad3dfe2dd06">
+            <Output></Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="685aeaf1-023c-4eb1-8727-fc6516eb1b61" testId="20aced79-1a63-4e66-d444-ee4575c65515" testName="NotRunnableTest" computerName="MYCOMPUTER" duration="00:00:00.0019388" startTime="2023-11-12T19:21:51.7042017-05:00" endTime="2023-11-12T19:21:51.7061961-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="685aeaf1-023c-4eb1-8727-fc6516eb1b61">
+            <Output>
+                <ErrorInfo>
+                    <Message>Test method MSTestSample.MockTestFixture.NotRunnableTest threw exception: &#xD;
+Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.ObjectModel.TestFailedException: Only data driven test methods can have parameters. Did you intend to use [DataRow] or [DynamicData]?</Message>
+                </ErrorInfo>
+            </Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="5dbc8cb9-4c3f-4b65-a138-30dcf8afd30e" testId="529a01f5-6c96-4f46-49f3-aa90b9f061b6" testName="TestWithException" computerName="MYCOMPUTER" duration="00:00:00.0005719" startTime="2023-11-12T19:21:51.7062325-05:00" endTime="2023-11-12T19:21:51.7068761-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5dbc8cb9-4c3f-4b65-a138-30dcf8afd30e">
+            <Output>
+                <ErrorInfo>
+                    <Message>Test method MSTestSample.MockTestFixture.TestWithException threw exception: &#xD;
+System.NotImplementedException: The method or operation is not implemented.</Message>
+                    <StackTrace>    at MSTestSample.MockTestFixture.TestWithException() in C:\dev\code\_Experiments\MSTestSample\UnitTest1.cs:line 70&#xD;
+                    </StackTrace>
+                </ErrorInfo>
+            </Output>
+        </UnitTestResult>
+        <UnitTestResult executionId="05c69927-e30b-4b5c-a5b8-2e44e9a88785" testId="c09170d3-a997-9a92-b6d5-9a86a4225591" testName="TestWithManyProperties" computerName="MYCOMPUTER" duration="00:00:00.0000490" startTime="2023-11-12T19:21:51.7069158-05:00" endTime="2023-11-12T19:21:51.7071317-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="05c69927-e30b-4b5c-a5b8-2e44e9a88785" />
+        
+        <UnitTestResult executionId="0942eb3b-2633-4c82-aa3a-374236dc6dab" testId="dac0f7bf-eced-b506-706a-66ed33c7be60" testName="TestWithArg (1)" computerName="MYCOMPUTER" duration="00:00:00.0000574" startTime="2023-11-12T19:21:51.7314236-05:00" endTime="2023-11-12T19:21:51.7362844-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0942eb3b-2633-4c82-aa3a-374236dc6dab" />
+        
+        
+    </Results>
+    <TestDefinitions>
+        <UnitTest name="FailingTest" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="5370a586-74b0-a647-4839-100eef3a4188">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="e01a54d8-305c-4828-9bc0-8c935270dafe" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="FailingTest" />
+        </UnitTest>
+        <UnitTest name="InconclusiveTest" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="2edb0741-aaff-135c-69bb-02a2e6d737cd">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="9915e227-fac8-4f88-b86c-a456bc7031a3" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="InconclusiveTest" />
+        </UnitTest>
+        <UnitTest name="MockTest1" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="8ed1bf6e-f1d2-7450-caab-53e4f5a4dd2c">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="a02c1a7d-98d2-4829-aacf-b818d4fd6e3e" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="MockTest1" />
+        </UnitTest>
+        <UnitTest name="MockTest2" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" priority="1" id="9475a122-272d-f5ef-87e4-fe7d1a7f0418">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+                <TestCategoryItem TestCategory="MockCategory" />
+            </TestCategory>
+            <Execution id="01f88d1f-7d8d-402d-9c18-bf81649b3296" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="MockTest2" />
+        </UnitTest>
+        <UnitTest name="MockTest3" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="6b0e8fc2-5324-dbeb-0c5f-0479cd14f351">
+            <TestCategory>
+                <TestCategoryItem TestCategory="MockCategory" />
+                <TestCategoryItem TestCategory="FixtureCategory" />
+                <TestCategoryItem TestCategory="AnotherCategory" />
+            </TestCategory>
+            <Execution id="4db5da11-faef-4e70-98d1-39ee00d6ed00" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="MockTest3" />
+        </UnitTest>
+        <UnitTest name="MockTest4" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="0b5c3ebb-3086-951a-1724-1821d30aef04">
+            <TestCategory>
+                <TestCategoryItem TestCategory="Foo" />
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="68e29212-0297-4843-8f1e-cad3dfe2dd06" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="MockTest4" />
+        </UnitTest>
+        <UnitTest name="NotRunnableTest" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="20aced79-1a63-4e66-d444-ee4575c65515">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="685aeaf1-023c-4eb1-8727-fc6516eb1b61" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="NotRunnableTest" />
+        </UnitTest>        
+        <UnitTest name="TestWithException" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="529a01f5-6c96-4f46-49f3-aa90b9f061b6">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="5dbc8cb9-4c3f-4b65-a138-30dcf8afd30e" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="TestWithException" />
+        </UnitTest>
+        <UnitTest name="TestWithManyProperties" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="c09170d3-a997-9a92-b6d5-9a86a4225591">
+            <TestCategory>
+                <TestCategoryItem TestCategory="FixtureCategory" />
+            </TestCategory>
+            <Execution id="05c69927-e30b-4b5c-a5b8-2e44e9a88785" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.MockTestFixture" name="TestWithManyProperties" />
+        </UnitTest>
+        <UnitTest name="TestWithArg (1)" storage="c:\dev\code\_experiments\nunitsample\mstestsample\bin\debug\net6.0\mstestsample.dll" id="dac0f7bf-eced-b506-706a-66ed33c7be60">
+            <Execution id="0942eb3b-2633-4c82-aa3a-374236dc6dab" />
+            <TestMethod codeBase="C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll" adapterTypeName="executor://mstestadapter/v2" className="MSTestSample.FixtureWithTestCases" name="TestWithArg" />
+        </UnitTest>
+    </TestDefinitions>
+    <TestEntries>
+        <TestEntry testId="c09170d3-a997-9a92-b6d5-9a86a4225591" executionId="05c69927-e30b-4b5c-a5b8-2e44e9a88785" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="529a01f5-6c96-4f46-49f3-aa90b9f061b6" executionId="5dbc8cb9-4c3f-4b65-a138-30dcf8afd30e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="9475a122-272d-f5ef-87e4-fe7d1a7f0418" executionId="01f88d1f-7d8d-402d-9c18-bf81649b3296" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="8ed1bf6e-f1d2-7450-caab-53e4f5a4dd2c" executionId="a02c1a7d-98d2-4829-aacf-b818d4fd6e3e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="2edb0741-aaff-135c-69bb-02a2e6d737cd" executionId="9915e227-fac8-4f88-b86c-a456bc7031a3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="dac0f7bf-eced-b506-706a-66ed33c7be60" executionId="0942eb3b-2633-4c82-aa3a-374236dc6dab" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="5370a586-74b0-a647-4839-100eef3a4188" executionId="e01a54d8-305c-4828-9bc0-8c935270dafe" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="0b5c3ebb-3086-951a-1724-1821d30aef04" executionId="68e29212-0297-4843-8f1e-cad3dfe2dd06" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="20aced79-1a63-4e66-d444-ee4575c65515" executionId="685aeaf1-023c-4eb1-8727-fc6516eb1b61" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestEntry testId="6b0e8fc2-5324-dbeb-0c5f-0479cd14f351" executionId="4db5da11-faef-4e70-98d1-39ee00d6ed00" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    </TestEntries>
+    <TestLists>
+        <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+        <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
+    </TestLists>
+    <ResultSummary outcome="Failed">
+        <Counters total="10" executed="8" passed="5" failed="3" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+        <Output>
+            <StdOut>Test 'InconclusiveTest' was skipped in the test run.&#xD;
+Test 'MockTest4' was skipped in the test run.&#xD;
+            </StdOut>
+        </Output>
+        <RunInfos>
+            <RunInfo computerName="MYCOMPUTER" outcome="Warning" timestamp="2023-11-12T19:21:51.6401483-05:00">
+                <Text>[MSTest][Discovery][C:\dev\code\_Experiments\MSTestSample\bin\Debug\net6.0\MSTestSample.dll] UTA007: Method MockTest5 defined in class MSTestSample.MockTestFixture does not have correct signature. Test method marked with the [TestMethod] attribute must be non-static, public, return-type as void  and should not take any parameter. Example: public void Test.Class1.Test(). Additionally, if you are using async-await in test method then return-type must be Task. Example: public async Task Test.Class1.Test2()</Text>
+            </RunInfo>
+        </RunInfos>
+    </ResultSummary>
+</TestRun>

--- a/PublishTestPlanResultsV1/test/data/nunit/nunit_v3.xml
+++ b/PublishTestPlanResultsV1/test/data/nunit/nunit_v3.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<test-run id="2" name="mock-assembly.dll" fullname="D:\Dev\NUnit\nunit-3.0\work\bin\vs2008\Debug\mock-assembly.dll" testcasecount="25" result="Failed" time="0.154" total="18" passed="12" failed="2" inconclusive="1" skipped="3" asserts="2" run-date="2011-07-26" start-time="11:34:27">
+  <environment nunit-version="1.0.0.0" clr-version="2.0.50727.4961" os-version="Microsoft Windows NT 6.1.7600.0" platform="Win32NT" cwd="D:\Dev\NUnit\nunit-3.0\work\bin\vs2008\Debug" machine-name="CHARLIE-LAPTOP" user="charlie" user-domain="charlie-laptop" culture="en-US" uiculture="en-US" />
+  <test-suite type="Assembly" id="1036" name="mock-assembly.dll" fullname="D:\Dev\NUnit\nunit-3.0\work\bin\vs2008\Debug\mock-assembly.dll" testcasecount="25" result="Failed" time="0.154" total="18" passed="12" failed="2" inconclusive="1" skipped="3" asserts="2">
+    <properties>
+      <property name="_PID" value="11928" />
+      <property name="_APPDOMAIN" value="test-domain-mock-assembly.dll" />
+    </properties>
+    <failure>
+      <message><![CDATA[Child test failed]]></message>
+    </failure>
+    <test-suite type="TestFixture" id="1000" name="MockTestFixture" fullname="NUnit.Tests.Assemblies.MockTestFixture" testcasecount="11" result="Failed" time="0.119" total="10" passed="4" failed="2" inconclusive="1" skipped="3" asserts="0">
+      <properties>
+        <property name="Category" value="FixtureCategory" />
+        <property name="Description" value="Fake Test Fixture" />
+      </properties>
+      <failure>
+        <message><![CDATA[Child test failed]]></message>
+      </failure>
+      <test-case id="1005" name="FailingTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.FailingTest" result="Failed" time="0.023" asserts="0">
+        <failure>
+          <message><![CDATA[Intentional failure]]></message>
+          <stack-trace><![CDATA[   at NUnit.Framework.Assert.Fail(String message, Object[] args) in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\framework\Assert.cs:line 142
+   at NUnit.Framework.Assert.Fail(String message) in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\framework\Assert.cs:line 152
+   at NUnit.Tests.Assemblies.MockTestFixture.FailingTest() in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\mock-assembly\MockAssembly.cs:line 121]]></stack-trace>
+        </failure>
+      </test-case>
+      <test-case id="1010" name="InconclusiveTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.InconclusiveTest" result="Inconclusive" time="0.001" asserts="0" />
+      <test-case id="1001" name="MockTest1" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest1" result="Passed" time="0.000" asserts="0">
+        <properties>
+          <property name="Description" value="Mock Test #1" />
+        </properties>
+      </test-case>
+      <test-case id="1002" name="MockTest2" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest2" result="Passed" time="0.000" asserts="0">
+        <properties>
+          <property name="Severity" value="Critical" />
+          <property name="Description" value="This is a really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really, really long description" />
+          <property name="Category" value="MockCategory" />
+        </properties>
+      </test-case>
+      <test-case id="1003" name="MockTest3" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest3" result="Passed" time="0.000" asserts="0">
+        <properties>
+          <property name="Category" value="AnotherCategory" />
+          <property name="Category" value="MockCategory" />
+        </properties>
+      </test-case>
+      <test-case id="1007" name="MockTest4" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest4" result="Skipped" label="Ignored" time="0.000" asserts="0">
+        <properties>
+          <property name="Category" value="Foo" />
+          <property name="_SKIPREASON" value="ignoring this test method for now" />
+        </properties>
+        <reason>
+          <message><![CDATA[ignoring this test method for now]]></message>
+        </reason>
+      </test-case>
+      <test-case id="1004" name="MockTest5" fullname="NUnit.Tests.Assemblies.MockTestFixture.MockTest5" result="Skipped" label="Invalid" time="0.000" asserts="0">
+        <properties>
+          <property name="_SKIPREASON" value="Method is not public" />
+        </properties>
+        <reason>
+          <message><![CDATA[Method is not public]]></message>
+        </reason>
+      </test-case>
+      <test-case id="1009" name="NotRunnableTest" fullname="NUnit.Tests.Assemblies.MockTestFixture.NotRunnableTest" result="Skipped" label="Invalid" time="0.000" asserts="0">
+        <properties>
+          <property name="_SKIPREASON" value="No arguments were provided" />
+        </properties>
+        <reason>
+          <message><![CDATA[No arguments were provided]]></message>
+        </reason>
+      </test-case>
+      <test-case id="1011" name="TestWithException" fullname="NUnit.Tests.Assemblies.MockTestFixture.TestWithException" result="Failed" label="Error" time="0.002" asserts="0">
+        <failure>
+          <message><![CDATA[System.ApplicationException : Intentional Exception]]></message>
+          <stack-trace><![CDATA[   at NUnit.Tests.Assemblies.MockTestFixture.MethodThrowsException() in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\mock-assembly\MockAssembly.cs:line 158
+   at NUnit.Tests.Assemblies.MockTestFixture.TestWithException() in D:\Dev\NUnit\nunit-3.0\work\NUnitFramework\src\mock-assembly\MockAssembly.cs:line 153]]></stack-trace>
+        </failure>
+      </test-case>
+      <test-case id="1006" name="TestWithManyProperties" fullname="NUnit.Tests.Assemblies.MockTestFixture.TestWithManyProperties" result="Passed" time="0.000" asserts="0">
+        <properties>
+          <property name="TargetMethod" value="SomeClassName" />
+          <property name="Size" value="5" />
+        </properties>
+      </test-case>
+    </test-suite>
+    <test-suite type="TestFixture" id="1023" name="BadFixture" fullname="NUnit.Tests.BadFixture" testcasecount="1" result="Skipped" label="Invalid" time="0.000" total="0" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <properties>
+        <property name="_SKIPREASON" value="No suitable constructor was found" />
+      </properties>
+      <reason>
+        <message><![CDATA[No suitable constructor was found]]></message>
+      </reason>
+    </test-suite>
+    <test-suite type="TestFixture" id="1025" name="FixtureWithTestCases" fullname="NUnit.Tests.FixtureWithTestCases" testcasecount="2" result="Passed" time="0.010" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="2">
+      <test-suite type="ParameterizedMethod" id="1026" name="MethodWithParameters" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters" testcasecount="2" result="Passed" time="0.009" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="2">
+        <test-case id="1027" name="MethodWithParameters(2,2)" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(2,2)" result="Passed" time="0.006" asserts="1" />
+        <test-case id="1028" name="MethodWithParameters(9,11)" fullname="NUnit.Tests.FixtureWithTestCases.MethodWithParameters(9,11)" result="Passed" time="0.000" asserts="1" />
+      </test-suite>
+    </test-suite>
+    <test-suite type="TestFixture" id="1016" name="IgnoredFixture" fullname="NUnit.Tests.IgnoredFixture" testcasecount="3" result="Skipped" label="Ignored" time="0.000" total="0" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <properties>
+        <property name="_SKIPREASON" value="" />
+      </properties>
+      <reason>
+        <message><![CDATA[]]></message>
+      </reason>
+    </test-suite>
+    <test-suite type="ParameterizedFixture" id="1029" name="ParameterizedFixture" fullname="NUnit.Tests.ParameterizedFixture" testcasecount="4" result="Passed" time="0.007" total="4" passed="4" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <test-suite type="TestFixture" id="1030" name="ParameterizedFixture(42)" fullname="NUnit.Tests.ParameterizedFixture(42)" testcasecount="2" result="Passed" time="0.003" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+        <test-case id="1031" name="Test1" fullname="NUnit.Tests.ParameterizedFixture(42).Test1" result="Passed" time="0.000" asserts="0" />
+        <test-case id="1032" name="Test2" fullname="NUnit.Tests.ParameterizedFixture(42).Test2" result="Passed" time="0.000" asserts="0" />
+      </test-suite>
+      <test-suite type="TestFixture" id="1033" name="ParameterizedFixture(5)" fullname="NUnit.Tests.ParameterizedFixture(5)" testcasecount="2" result="Passed" time="0.002" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+        <test-case id="1034" name="Test1" fullname="NUnit.Tests.ParameterizedFixture(5).Test1" result="Passed" time="0.000" asserts="0" />
+        <test-case id="1035" name="Test2" fullname="NUnit.Tests.ParameterizedFixture(5).Test2" result="Passed" time="0.000" asserts="0" />
+      </test-suite>
+    </test-suite>
+    <test-suite type="TestFixture" id="1012" name="OneTestCase" fullname="NUnit.Tests.Singletons.OneTestCase" testcasecount="1" result="Passed" time="0.001" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <test-case id="1013" name="TestCase" fullname="NUnit.Tests.Singletons.OneTestCase.TestCase" result="Passed" time="0.000" asserts="0" />
+    </test-suite>
+    <test-suite type="TestFixture" id="1014" name="MockTestFixture" fullname="NUnit.Tests.TestAssembly.MockTestFixture" testcasecount="1" result="Passed" time="0.001" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+      <test-case id="1015" name="MyTest" fullname="NUnit.Tests.TestAssembly.MockTestFixture.MyTest" result="Passed" time="0.001" asserts="0" />
+    </test-suite>
+  </test-suite>
+</test-run>

--- a/PublishTestPlanResultsV1/test/data/testng/single-suite.xml
+++ b/PublishTestPlanResultsV1/test/data/testng/single-suite.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testng-results skipped="0" failed="0" total="4" passed="4">
+  <reporter-output>
+  </reporter-output>
+  <suite name="Default suite" duration-ms="2000" started-at="2015-03-10T06:11:58Z" finished-at="2015-03-10T06:11:58Z">
+    <groups>
+    </groups>
+    <test name="Default test" duration-ms="2000" started-at="2015-03-10T06:11:58Z" finished-at="2015-03-10T06:11:58Z">
+      <class name="com.javacodegeeks.testng.reports.TestClass2">
+        <test-method status="PASS" signature="c2()[pri:0, ic2@1c2c22f3]" name="c2" duration-ms="0" started-at="2015-03-10T11:41:58Z" finished-at="2015-03-10T11:41:58Z">
+          <reporter-output>
+          </reporter-output>
+        </test-method> <!-- c2 -->
+        <test-method status="PASS" signature="c3()[pri:0, ic2@1c2c22f3]" name="c3" duration-ms="10" started-at="2015-03-10T11:41:58Z" finished-at="2015-03-10T11:41:58Z">
+          <reporter-output>
+          </reporter-output>
+        </test-method> <!-- c3 -->
+        <test-method status="PASS" signature="c1()[pri:0, ic2@1c2c22f3]" name="c1" duration-ms="0" started-at="2015-03-10T11:41:58Z" finished-at="2015-03-10T11:41:58Z">
+          <reporter-output>
+          </reporter-output>
+        </test-method> <!-- c1 -->
+        <test-method status="PASS" signature="c4()[pri:0, ic2@1c2c22f3]" name="c4" duration-ms="0" started-at="2015-03-10T11:41:58Z" finished-at="2015-03-10T11:41:58Z">
+          <exception class="java.lang.AssertionError">
+            <message>
+              <![CDATA[expected [true] but found [false]]]>
+            </message>
+            <full-stacktrace>
+              <![CDATA[expected [true] but found [false]]]>
+            </full-stacktrace> 
+          </exception> 
+          <reporter-output> 
+          </reporter-output> 
+        </test-method>
+      </class> 
+    </test> 
+  </suite> 
+</testng-results>


### PR DESCRIPTION
- Modified `testResultFormat` to be a pickList.
- `testResultFormat` is case now insensitive
- Cucumber, NUnit, TestNG and Mocha are now available for selection
