### PR TITLE
Bugfix/improve error handling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,21 +4,34 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
-
 **Description**
+
 _provide a clear and concise description of what the bug is_
 
 _provide sample usage of the task, if applicable_
+
 ```yaml
 - task: PublishTestPlanResults@0
   inputs:
 ```
 
-With the following environment:
-- build-agent:  self-hosted, microsoft-hosted
+**Environment Details**
+
+_provide details about your pipeline environment_
+
+- build-agent: self-hosted / microsoft-hosted
 - test-format: xUnit / jUnit / Cucumber
+- test-lanugage: C# / Java / JavaScript / Other ___
+- pipeline-format: yaml / Designer-based (Classic)
+
+**Pipeline Output**
+
+_provide output from the build with diagnostics enabled (system.debug variable set to 'true'). Mask secrets or sensitive information with xxx_:
+
+```shell
+paste your build output here
+```
 
 **To Reproduce**
 Steps to reproduce the behaviour:
@@ -28,10 +41,13 @@ Steps to reproduce the behaviour:
 4. See error
 
 **Expected behaviour**
+
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
 **Additional context**
+
 Add any other context about the problem here.

--- a/PublishTestPlanResultsV1/.gitignore
+++ b/PublishTestPlanResultsV1/.gitignore
@@ -3,3 +3,4 @@ coverage
 *.js
 *.js.map
 .taskkey
+results.xml

--- a/PublishTestPlanResultsV1/Test-ExtensionLocally.ps1
+++ b/PublishTestPlanResultsV1/Test-ExtensionLocally.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+  This script is intended to support local development efforts by testing the extension outside of a pipeline.
+
+.NOTES
+  To run:
+  - compile the extension 'tsc'
+  - set any frequently used task parameters as environment variables in advance $env:INPUT_<variable>="<value>"
+  - run this script without parameters. supply values or press enter to continue
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$CollectionUri,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$ProjectName,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$AccessToken,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestResultFormat,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestResultFiles,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestPlan,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestConfigFilter,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestConfigAliases,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestCaseMatchStrategy,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestCaseProperty,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestCaseRegex,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestConfigProperty,
+
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$TestRunTitle,
+
+  [switch]$DebugMode
+
+)
+$PSBoundParameters.GetEnumerator() | ForEach-Object {
+  if ($_.Value -ne $null) {
+    $key = "INPUT_$($_.Key)"
+    [System.Environment]::SetEnvironmentVariable($key, $_.Value)
+  }  
+}
+
+if ($DebugMode.IsPresent) {
+  node --inspect index.js 
+} else {
+  node index.js
+}

--- a/PublishTestPlanResultsV1/context/TestResultContext.ts
+++ b/PublishTestPlanResultsV1/context/TestResultContext.ts
@@ -68,6 +68,7 @@ export class TestResultContext {
     }
     return this.supportedTestConfigs.get(alias) as TestConfiguration;
   }
+
   getTestConfigs(alias : string | undefined) : Map<string,TestConfiguration> {
     if (alias) {
       if (! this.hasConfig(alias)) {
@@ -86,8 +87,6 @@ export class TestResultContext {
     } else {
       return this.supportedTestConfigs;
     }
-    
-    
   }
 
   hasConfig(name: string): boolean {

--- a/PublishTestPlanResultsV1/context/TestResultContextBuilder.ts
+++ b/PublishTestPlanResultsV1/context/TestResultContextBuilder.ts
@@ -10,6 +10,7 @@ export class TestResultContextBuilder {
   static async setup(parameters: TestResultContextParameters): Promise<TestResultContextBuilder> {
     // construct builder
     var log = getLogger();
+    log.debug(`Initializing connection to ${parameters.collectionUri} ...`);
     var adoClientWrapper = await AdoWrapper.createInstance(parameters.collectionUri, parameters.accessToken);
     var builder = new TestResultContextBuilder(log, adoClientWrapper);
 
@@ -46,7 +47,7 @@ export class TestResultContextBuilder {
     if (configs) {
       this.log.debug(`${configs.length} test configurations available.`);
       configs.forEach((config: any) => {
-        this.log.debug(`config : ${config.name}`);
+        this.log.debug(`config : ${config.name} (${config.id})`);
         ctx.addConfig(config)
       });
     }
@@ -66,7 +67,7 @@ export class TestResultContextBuilder {
   }
 
   private async getAndValidateProjectName(): Promise<string> {
-    this.log.debug("validating ado connection");
+    this.log.debug("validating ado connection by resolving project name");
     try {
       return await this.ado.getProjectId(this.projectName as string);
     }

--- a/PublishTestPlanResultsV1/context/TestResultContextBuilder.ts
+++ b/PublishTestPlanResultsV1/context/TestResultContextBuilder.ts
@@ -44,12 +44,15 @@ export class TestResultContextBuilder {
     let ctx = new TestResultContext(projectId, (this.projectName as string), testPlan);
     let configs = await this.getTestConfigurations();
     if (configs) {
+      this.log.debug(`${configs.length} test configurations available.`);
       configs.forEach((config: any) => {
+        this.log.debug(`config : ${config.name}`);
         ctx.addConfig(config)
       });
     }
 
     this.testConfigAlises?.forEach(alias => {
+      this.log.debug(`config alias: ${alias.alias}=${alias.config}`);
       ctx.addConfigAlias(alias);
     });
 
@@ -57,6 +60,7 @@ export class TestResultContextBuilder {
 
     let points = await this.getTestPoints(projectId, testPlan, testConfigFilterId);
     ctx.addTestPoints(points);
+    this.log.info(`Available Test Points: ${points.length}`);
 
     return ctx;
   }
@@ -120,14 +124,18 @@ export class TestResultContextBuilder {
 
     return await this.ado.getTestConfigurations((this.projectName as string));
   }
+
   private getAndValidateTestConfigFilter(ctx : TestResultContext) : string | undefined {
     // validate that the testConfigFilter refers to a valid config
     if (this.testConfig) {
+      this.log.debug("validating testConfigFilter");
       if (!ctx.hasConfig(this.testConfig)) {
         throw new Error(`Test config filter refers to an unrecognized configuration '${this.testConfig}'.`);
       }
       
-      return ctx.getTestConfig(this.testConfig).id.toString();
+      let configId = ctx.getTestConfig(this.testConfig).id.toString();
+      this.log.info(`Using Test Config: ${this.testConfig} (${configId})`);
+      return configId;
     }
 
     return undefined;

--- a/PublishTestPlanResultsV1/framework/TestFrameworkResultReader.ts
+++ b/PublishTestPlanResultsV1/framework/TestFrameworkResultReader.ts
@@ -2,11 +2,18 @@ import { TestFrameworkFormat } from "./TestFrameworkFormat";
 import { TestFrameworkParameters } from "./TestFrameworkParameters";
 import { TestFrameworkResult } from "./TestFrameworkResult";
 import { parse, ParseOptions } from 'test-results-parser';
+import { ILogger, getLogger } from "../services/Logger"
+import { stringify } from "querystring";
 
 export async function readResults(parameters: TestFrameworkParameters): Promise<TestFrameworkResult[]> {
 
+
+  let logger = getLogger();
+
   // read test files
+  logger.debug("converting test framework results into unified format");
   let testResult = parse({ type: parameters.testFormat.toString(), files: parameters.testFiles });
+  logger.debug(JSON.stringify(testResult));
 
   var results: TestFrameworkResult[] = [];
 

--- a/PublishTestPlanResultsV1/index.ts
+++ b/PublishTestPlanResultsV1/index.ts
@@ -9,6 +9,11 @@ async function run() {
 
   try {
 
+    if (process.execArgv.includes("--inspect")) {
+      console.log(`Waiting for debugger. Process ${process.pid}`);
+      await new Promise( resolve => setTimeout(resolve, 30000));
+    }
+
     // construct the context by locating the test plan,
     // populating the test points and supported configurations
     const contextParameters = TaskParameters.getTestContextParameters();

--- a/PublishTestPlanResultsV1/index.ts
+++ b/PublishTestPlanResultsV1/index.ts
@@ -7,6 +7,8 @@ import { TestRunPublisher } from "./publishing/TestRunPublisher";
 
 async function run() {
 
+  try {
+
     // construct the context by locating the test plan,
     // populating the test points and supported configurations
     const contextParameters = TaskParameters.getTestContextParameters();
@@ -27,6 +29,16 @@ async function run() {
     const publisherParameters = TaskParameters.getPublisherParameters();
     const publisher = await TestRunPublisher.create(publisherParameters);
     await publisher.publishTestRun(testRunData);
+
+    tl.setResult(tl.TaskResult.Succeeded,'');
+
+  } catch (err) {
+    if (err instanceof Error) {
+      tl.setResult(tl.TaskResult.Failed, err.message);
+    } else {
+      tl.setResult(tl.TaskResult.Failed, 'An unhandled error occurred.');
+    }
+  }
 }
 
 run();

--- a/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
+++ b/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
@@ -52,7 +52,7 @@ export class TestConfigMatchStrategy implements TestResultMatchStrategy {
 
     // comparing the test point should not be necessary if a 
     // defaultConfigFilter has been set, but we should safe-guard this value
-    if (!this.allowedConfigs.has(point.configuration.id as string)) {
+    if (!this.allowedConfigs.has(point.configuration.id?.toString() as string)) {
       return TestResultMatch.Fail;
     }
       

--- a/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
+++ b/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
@@ -2,13 +2,9 @@ import { TestResultProcessor } from "./TestResultProcessor";
 import { TestResultProcessorParameters } from "./TestResultProcessorParameters";
 import { TestResultMatchStrategy, TestResultMatch, TestCaseMatchingStrategy } from "./TestResultMatchStrategy";
 import { TestFrameworkResult } from "../framework/TestFrameworkResult";
-import { TestConfiguration, TestPoint, WorkItemReference } from "azure-devops-node-api/interfaces/TestInterfaces";
+import { TestConfiguration, TestPoint } from "azure-devops-node-api/interfaces/TestInterfaces";
+import { TestPoint2 } from '../services/AdoWrapper';
 import { TestResultContext } from "../context/TestResultContext";
-
-interface TestPointWithTestCaseReference extends TestPoint {
-  // TestPoint defines a property called 'testCase' but in the data it's actually testCaseReference
-  testCaseReference: WorkItemReference;
-}
 
 export function create( parameters : TestResultProcessorParameters, context : TestResultContext ) : TestResultProcessor {
 
@@ -91,7 +87,7 @@ export class TestNameMatchStrategy implements TestResultMatchStrategy {
 
   isMatch( result : TestFrameworkResult, point : TestPoint) : TestResultMatch {
     
-    if (this.simplify(result.name) == this.simplify((point as TestPointWithTestCaseReference).testCaseReference.name!)) {
+    if (this.simplify(result.name) == this.simplify((point as TestPoint2).testCaseReference.name!)) {
       return TestResultMatch.Exact;
     }
 
@@ -118,7 +114,7 @@ export class TestRegexMatchStrategy implements TestResultMatchStrategy {
       let match : RegExpExecArray | null;
       if ((match = this.regex.exec(result.name)) !== null) {
         let testCaseId = match[0];
-        return testCaseId == (point as TestPointWithTestCaseReference).testCaseReference.id ?
+        return testCaseId == (point as TestPoint2).testCaseReference.id ?
           TestResultMatch.Exact : TestResultMatch.Fail;
       }
     }
@@ -157,7 +153,7 @@ export class TestIdMatchStrategy implements TestResultMatchStrategy {
     if (result.properties.has(this.testCaseIdProperty)) {
       let testCaseId = result.properties.get(this.testCaseIdProperty);
 
-      return (testCaseId && testCaseId == (point as TestPointWithTestCaseReference).testCaseReference.id) ?
+      return (testCaseId && testCaseId == (point as TestPoint2).testCaseReference.id) ?
         TestResultMatch.Exact : TestResultMatch.Fail;
     }
 

--- a/PublishTestPlanResultsV1/publishing/TestRunPublisher.ts
+++ b/PublishTestPlanResultsV1/publishing/TestRunPublisher.ts
@@ -37,6 +37,8 @@ export class TestRunPublisher {
       return Promise.resolve(undefined);
     }
 
+    this.logger.debug("Publishing test results...");
+
     if (results.matches.size > 0) {
 
       const testPlanId = results.testPlan.id;

--- a/PublishTestPlanResultsV1/services/AdoWrapper.ts
+++ b/PublishTestPlanResultsV1/services/AdoWrapper.ts
@@ -185,6 +185,7 @@ export class AdoWrapper {
    * @returns the updated TestRun object
    */
   async updateTestRun(projectId : string, testRun : Contracts.TestRun) : Promise<Contracts.TestRun> {
+    this.logger.debug(`updating TestRun (state=${testRun.state})`);
     let updateModel = <Contracts.RunUpdateModel>{ 
       build: testRun.build,
       comment: testRun.comment,

--- a/PublishTestPlanResultsV1/services/AdoWrapper.ts
+++ b/PublishTestPlanResultsV1/services/AdoWrapper.ts
@@ -10,6 +10,14 @@ interface AdoResponseHeaders {
   "x-ms-continuationtoken"? : string;
 }
 
+/* 
+  there is a bug in the azure-devops-node-api that defines a testCase, but it's actually testCaseReference.
+  this is a temporary workaround until this issue is corrected in the node api
+*/
+export interface TestPoint2 extends Contracts.TestPoint {
+  testCaseReference : Contracts.WorkItemReference
+}
+
 export class AdoWrapper {
 
   static async createInstance(server : string, accessToken : string) : Promise<AdoWrapper> {

--- a/PublishTestPlanResultsV1/test/TestResultContextBuilder.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestResultContextBuilder.specs.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as testUtil from './testUtil';
 import { newShallowReference, newTestConfig, newTestPlan, newTestPoint } from './testUtil';
-import { TestPlan, TestConfiguration, TestPoint, ShallowReference, WorkItemReference } from 'azure-devops-node-api/interfaces/TestInterfaces';
-import { AdoWrapper } from '../services/AdoWrapper';
+import { TestPlan, TestConfiguration, TestPoint } from 'azure-devops-node-api/interfaces/TestInterfaces';
+import { AdoWrapper, TestPoint2 } from '../services/AdoWrapper';
 import { ILogger, NullLogger } from '../services/Logger';
 import { TestResultContextBuilder } from '../context/TestResultContextBuilder';
 import { configAlias } from '../context/configAlias';
@@ -212,8 +212,8 @@ describe("TestResultContextBuilder", () => {
         // assert
         let points = result.getTestPoints();
         expect(points.length).to.eq(2);
-        expect((points[0] as any).testCaseReference.name).to.eq("Test Case 1");
-        expect((points[1] as any).testCaseReference.name).to.eq("Test Case 4");
+        expect((points[0] as TestPoint2).testCaseReference.name).to.eq("Test Case 1");
+        expect((points[1] as TestPoint2).testCaseReference.name).to.eq("Test Case 4");
       });
 
       it("Should recognize when test config filter is not a valid config", async () =>{
@@ -250,10 +250,10 @@ describe("TestResultContextBuilder", () => {
         // assert
         let points = result.getTestPoints();
         expect(points.length).to.eq(4);
-        expect((points[0] as any).testCaseReference.name).to.eq("Test Case 1");
-        expect((points[1] as any).testCaseReference.name).to.eq("Test Case 2");
-        expect((points[2] as any).testCaseReference.name).to.eq("Test Case 3");
-        expect((points[3] as any).testCaseReference.name).to.eq("Test Case 4");
+        expect((points[0] as TestPoint2).testCaseReference.name).to.eq("Test Case 1");
+        expect((points[1] as TestPoint2).testCaseReference.name).to.eq("Test Case 2");
+        expect((points[2] as TestPoint2).testCaseReference.name).to.eq("Test Case 3");
+        expect((points[3] as TestPoint2).testCaseReference.name).to.eq("Test Case 4");
       });
     });
   })  

--- a/PublishTestPlanResultsV1/test/TestResultContextBuilder.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestResultContextBuilder.specs.ts
@@ -212,8 +212,8 @@ describe("TestResultContextBuilder", () => {
         // assert
         let points = result.getTestPoints();
         expect(points.length).to.eq(2);
-        expect(points[0].testCase.name).to.eq("Test Case 1");
-        expect(points[1].testCase.name).to.eq("Test Case 4");
+        expect((points[0] as any).testCaseReference.name).to.eq("Test Case 1");
+        expect((points[1] as any).testCaseReference.name).to.eq("Test Case 4");
       });
 
       it("Should recognize when test config filter is not a valid config", async () =>{
@@ -250,10 +250,10 @@ describe("TestResultContextBuilder", () => {
         // assert
         let points = result.getTestPoints();
         expect(points.length).to.eq(4);
-        expect(points[0].testCase.name).to.eq("Test Case 1");
-        expect(points[1].testCase.name).to.eq("Test Case 2");
-        expect(points[2].testCase.name).to.eq("Test Case 3");
-        expect(points[3].testCase.name).to.eq("Test Case 4");
+        expect((points[0] as any).testCaseReference.name).to.eq("Test Case 1");
+        expect((points[1] as any).testCaseReference.name).to.eq("Test Case 2");
+        expect((points[2] as any).testCaseReference.name).to.eq("Test Case 3");
+        expect((points[3] as any).testCaseReference.name).to.eq("Test Case 4");
       });
     });
   })  

--- a/PublishTestPlanResultsV1/test/TestResultMatchStrategy.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestResultMatchStrategy.specs.ts
@@ -6,9 +6,6 @@ import { TestConfigMatchStrategy, TestIdMatchStrategy, TestNameMatchStrategy, Te
 import { TestResultMatch } from "../processing/TestResultMatchStrategy";
 import * as util from './testUtil';
 
-
-
-
 describe("TestCaseMatchStrategy", () => {
 
   var test : TestFrameworkResult;
@@ -91,7 +88,7 @@ describe("TestCaseMatchStrategy", () => {
     var subject : TestNameMatchStrategy = new TestNameMatchStrategy();
     
     before(() => {
-      point = <TestPoint>{ id: 1000, testCase: <WorkItemReference>{ name: "The Name of The Test"}};
+      point = <any>{ id: 1000, testCaseReference: <WorkItemReference>{ name: "The Name of The Test"}};
     })
 
     it("Should match test result name that contains spaces", () => {
@@ -155,7 +152,7 @@ describe("TestCaseMatchStrategy", () => {
     var subject : TestRegexMatchStrategy;
 
     before(() => {
-      point = <TestPoint>{ id: 1000, testCase: <WorkItemReference>{ id:"1234"}};
+      point = <any>{ id: 1000, testCaseReference: <WorkItemReference>{ id:"1234"}};
     })
 
     it("Should  find test case id at end of test name", () => {
@@ -246,7 +243,7 @@ describe("TestCaseMatchStrategy", () => {
 
     beforeEach(() => {
       test = new TestFrameworkResult("MyAutomatedTest","FAIL");
-      point = <TestPoint>{ id: 1000, testCase: <WorkItemReference>{ id: "1" }};
+      point = <any>{ id: 1000, testCaseReference: <WorkItemReference>{ id: "1" }};
       subject = new TestIdMatchStrategy("TestCase");
     })
     

--- a/PublishTestPlanResultsV1/test/testUtil.ts
+++ b/PublishTestPlanResultsV1/test/testUtil.ts
@@ -74,9 +74,9 @@ export function newTestPlan(id : number = 0, name? : string, endDate? : Date) : 
 }
 
 export function newTestPoint(id : number = 0, name : string = "Test 1", configId : string = "0", testCaseId : string = "0" ) {
-  return <TestPoint>{ 
+  return <any>{ 
     id: id, 
-    testCase: <WorkItemReference>{
+    testCaseReference: <WorkItemReference>{ /*TestPoint has testCase, but it should be testCaseReference*/
       id: testCaseId,
       name: name
     },

--- a/PublishTestPlanResultsV1/test/testUtil.ts
+++ b/PublishTestPlanResultsV1/test/testUtil.ts
@@ -1,6 +1,7 @@
 import im = require('azure-pipelines-task-lib/internal');
 import * as assert from 'assert'
-import { ShallowReference, TestPlan, TestConfiguration, TestPoint, WorkItemReference } from 'azure-devops-node-api/interfaces/TestInterfaces';
+import { ShallowReference, TestPlan, TestConfiguration, WorkItemReference } from 'azure-devops-node-api/interfaces/TestInterfaces';
+import { TestPoint2 } from '../services/AdoWrapper';
 import { TestFrameworkResult } from '../framework/TestFrameworkResult';
 
 export function setSystemVariable(name: string, val: string) {
@@ -74,7 +75,7 @@ export function newTestPlan(id : number = 0, name? : string, endDate? : Date) : 
 }
 
 export function newTestPoint(id : number = 0, name : string = "Test 1", configId : string = "0", testCaseId : string = "0" ) {
-  return <any>{ 
+  return <TestPoint2>{ 
     id: id, 
     testCaseReference: <WorkItemReference>{ /*TestPoint has testCase, but it should be testCaseReference*/
       id: testCaseId,


### PR DESCRIPTION
- Added additional logging to support troubleshooting
- Added support for local execution and attaching a debugger
- Fixed issue with aggressive test config filtering
- Fixed issue with testCaseReference in nodejs SDK

To test locally:

1. Compile the extension (`tsc`)
2. Set breakpoints where appropriate
3. Open a command-prompt and start PowerShell Core (`pwsh.exe`)
4. Run the supplied PowerShell script:

   ```powershell
   cd PublishTestPlanResultsV1
   .\Test-ExtensionLocally.ps1 -DebugMode
   ```

5. Provide the necessary values when prompted or press `enter` to accept default values. To provide default values, create environment variables `INPUT_<variable-name-in-prompt>`
6. In VSCode, use `> Attach to NodeJs process`. Provide the PID that appears in the command-output.
