### PR TITLE
Fix for JUnit result parsing

### DIFF
--- a/PublishTestPlanResultsV1/framework/TestFrameworkFormat.ts
+++ b/PublishTestPlanResultsV1/framework/TestFrameworkFormat.ts
@@ -4,6 +4,6 @@ export enum TestFrameworkFormat {
   cucumber = "cucumber",
   mocha = "mocha",
   nunit = "nunit",
-  testng = "testng"
-  //mstest = "mstest"
+  testng = "testng",
+  mstest = "mstest"
 }

--- a/PublishTestPlanResultsV1/framework/TestFrameworkResultReader.ts
+++ b/PublishTestPlanResultsV1/framework/TestFrameworkResultReader.ts
@@ -23,7 +23,8 @@ export async function readResults(parameters: TestFrameworkParameters): Promise<
       let result = new TestFrameworkResult(test.name, test.status);
       result.failure = test.failure;
       result.stacktrace = test.stack_trace;
-      result.properties = test.meta_data;
+      // 0.1.19 separated tags from metadata
+      result.properties = new Map<string,string>(Object.entries(test.metadata));
 
       results.push(result);
     })

--- a/PublishTestPlanResultsV1/package-lock.json
+++ b/PublishTestPlanResultsV1/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "azure-devops-node-api": "^12.1.0",
         "azure-pipelines-task-lib": "^4.6.1",
-        "test-results-parser": "^0.1.7"
+        "test-results-parser": "0.1.19"
       },
       "devDependencies": {
         "@types/chai": "^4.3.11",
@@ -1069,9 +1069,9 @@
       }
     },
     "node_modules/test-results-parser": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/test-results-parser/-/test-results-parser-0.1.7.tgz",
-      "integrity": "sha512-PmjhJm+PY9v1WjAWcS8bkVSv0GbHrb7SJaTC2E9civaACf7osU7ayF7fIe56gDuJZLNOlCsCfbDoIZHC89eAoQ==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/test-results-parser/-/test-results-parser-0.1.19.tgz",
+      "integrity": "sha512-Q3iAZWRz/DvSS+ecPys29WUsMRybsURwYvkuqdCcmYPHUBcyUPrKDQDGRLSFPMI8b44XfDHh67+RVTFg7mOgQQ==",
       "dependencies": {
         "fast-xml-parser": "^4.3.2",
         "globrex": "^0.1.2",

--- a/PublishTestPlanResultsV1/package-lock.json
+++ b/PublishTestPlanResultsV1/package-lock.json
@@ -412,9 +412,9 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",

--- a/PublishTestPlanResultsV1/package.json
+++ b/PublishTestPlanResultsV1/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "azure-devops-node-api": "^12.1.0",
     "azure-pipelines-task-lib": "^4.6.1",
-    "test-results-parser": "^0.1.7"
+    "test-results-parser": "0.1.19"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",

--- a/PublishTestPlanResultsV1/task.json
+++ b/PublishTestPlanResultsV1/task.json
@@ -97,7 +97,8 @@
                 "cucumber": "cucumber",
                 "nUnit": "nUnit",
                 "testng": "testng",
-                "mocha": "mocha"
+                "mocha": "mocha",
+                "mstest": "mstest"
             },
             "helpMarkDown": "Represents which compatible framework the test results are formatted in. (JUnit, XUnit, TestNG, Mocha, Cucumber, etc)"
         },

--- a/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
@@ -22,6 +22,9 @@ describe("TestFramework Results Reader", () => {
 
     // assert
     expect(results.length).to.eq(1);
+    expect(String(results[0].properties.get("TestID"))).to.equal('1234');
+    expect(results[0].properties.get("TestLevel")).to.equal('Regression');
+    expect(results[0].properties.get("TestProduct")).to.equal('TestProductExample');
   });
  
  

--- a/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
@@ -93,20 +93,18 @@ describe("TestFramework Results Reader", () => {
     expect(results.length).to.be.greaterThan(1);
   });
 
-
-  // waiting for 0.1.7 that includes this
-  // it("Can read MStests results", async () => {
-  //   // arrange
-  //   var files = [];
-  //   files.push(path.join(baseDir, "mstest", "testresults.trx"));
-  //   var parameters = new TestFrameworkParameters(files, "mstest");
+  it("Can read MStests results", async () => {
+    // arrange
+    var files = [];
+    files.push(path.join(baseDir, "mstest", "testresults.trx"));
+    var parameters = new TestFrameworkParameters(files, "mstest");
     
-  //   // act
-  //   var results = await TestFrameworkResultReader.readResults(parameters);
+    // act
+    var results = await TestFrameworkResultReader.readResults(parameters);
 
-  //   // assert
-  //   expect(results.length).to.eq(1);
-  // });
+    // assert
+    expect(results.length).to.eq(10);
+  });
 
 
 })


### PR DESCRIPTION
Bump test-results-parser to 0.1.19 which includes:

- Separation of tags and metadata. This shouldn't impact test result processing, but there could be an impact on using MSTest or xUnit Category.
- Fixes for JUnit test results
- Fixes for JUnit stack-traces
- Parsing of attachments
- MSTest support
