### PR TITLE
Include Build Id in TestRun

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ tsc
 To execute the mocha tests:
 
 1. Open VSCode from the `\PublishTestPlanResultsV1` folder
-1. Install the "Mocha Test Explorer" extension
+1. Install the "[Mocha Test Explorer](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-mocha-test-adapter)" extension
 1. Modify the .vscode settings file and adjust the `mochaExplorer.env` with variables that reflect your environment:
    - SYSTEM_COLLECTIONURI: the URL to your Azure DevOps Organization
    - SYSTEM_ACCESSTOKEN: PAT token to your Azure DevOps Organization
@@ -47,5 +47,5 @@ Prior to checking the changes in, please test out your changes locally:
    .\Test-ExtensionLocally.ps1 -DebugMode
    ```
 
-1. Provide the necessary values when prompted or press `enter` to accept default values. To provide default values, create environment variables `INPUT_<variable-name-in-prompt>`
+1. Provide the necessary values when prompted or press `enter` to accept default values. To provide prepopulated answers for these prompts, create environment variables `INPUT_<variable-name-in-prompt>`.
 1. In VSCode, use `> Attach to NodeJs process`. Provide the PID that appears in the command-output.

--- a/PublishTestPlanResultsV1/TaskParameters.ts
+++ b/PublishTestPlanResultsV1/TaskParameters.ts
@@ -71,8 +71,9 @@ export function getProcessorParameters() : TestResultProcessorParameters {
 
 export function getPublisherParameters() : TestRunPublisherParameters {
   const accessToken = tl.getInput("accessToken", false) ?? tl.getVariable("SYSTEM_ACCESSTOKEN");
+  const buildId = tl.getVariable("BUILD_BUILDID"); // available in build and release pipelines
   const collectionUri = tl.getInput("collectionUri", false) ?? tl.getVariable("SYSTEM_COLLECTIONURI");
   const dryRun = tl.getBoolInput("dryRun", false);
   const testRunTitle = tl.getInput("testRunTitle", false) ?? "PublishTestPlanResult";
-  return new TestRunPublisherParameters(collectionUri as string, accessToken as string, dryRun, testRunTitle);
+  return new TestRunPublisherParameters(collectionUri as string, accessToken as string, dryRun, testRunTitle, buildId as string);
 }

--- a/PublishTestPlanResultsV1/Test-ExtensionLocally.ps1
+++ b/PublishTestPlanResultsV1/Test-ExtensionLocally.ps1
@@ -10,15 +10,15 @@
 #>
 [CmdletBinding()]
 param(
-  [Parameter(Mandatory)]
+  [Parameter(Mandatory, HelpMessage="Defaults to $\(System.CollectionUri\), set SYSTEM_COLLECTIONURI to override")]
   [AllowEmptyString()]
   [string]$CollectionUri,
 
-  [Parameter(Mandatory)]
+  [Parameter(Mandatory, HelpMessage="Defaults to $\(System.ProjectName\) set SYSTEM_PROJECTNAME to override")]
   [AllowEmptyString()]
   [string]$ProjectName,
 
-  [Parameter(Mandatory)]
+  [Parameter(Mandatory, HelpMessage="Defaults to $\(System.AccessToken\), set SYSTEM_ACCESSTOKEN to override")]
   [AllowEmptyString()]
   [string]$AccessToken,
 
@@ -63,6 +63,9 @@ param(
   [string]$TestRunTitle,
 
   [Parameter(Mandatory)]
+  [string]$BuildId,
+
+  [Parameter(Mandatory)]
   [AllowEmptyString()]
   [string]$DryRun,
 
@@ -75,11 +78,14 @@ if ($DryRun -ne "") {
 }
 
 $PSBoundParameters.GetEnumerator() | ForEach-Object {
-  if ($_.Value -ne $null) {
+  if (($_.Value -ne $null) -or $_.Value -ne "") {
     $key = "INPUT_$($_.Key)"
     [System.Environment]::SetEnvironmentVariable($key, $_.Value)
   }  
 }
+
+# BuildId isn't an input parameter.
+[System.Environment]::SetEnvironmentVariable("BUILD_BUILDID", $BuildId)
 
 if ($DebugMode.IsPresent) {
   [System.Environment]::SetEnvironmentVariable("SYSTEM_DEBUG", "true");

--- a/PublishTestPlanResultsV1/publishing/TestRunPublisher.ts
+++ b/PublishTestPlanResultsV1/publishing/TestRunPublisher.ts
@@ -8,10 +8,11 @@ import { TestFrameworkResult } from "../framework/TestFrameworkResult";
 export class TestRunPublisher {
 
   static async create( parameters : TestRunPublisherParameters) : Promise<TestRunPublisher> {
-    var ado = await AdoWrapper.createInstance(parameters.collectionUri,parameters.accessToken);
+    var ado = await AdoWrapper.createInstance(parameters.collectionUri, parameters.accessToken);
     var logger = getLogger();
 
     var publisher = new TestRunPublisher(ado, logger);
+    publisher.buildId = parameters.buildId;
     publisher.dryRun = parameters.dryRun;
     publisher.testRunTitle = parameters.testRunTitle;
 
@@ -20,12 +21,14 @@ export class TestRunPublisher {
 
   private ado : AdoWrapper;
   private logger : ILogger;
+  public buildId : string;
   public dryRun : boolean;
   public testRunTitle : string;
 
   constructor(ado : AdoWrapper, logger : ILogger) {
     this.ado = ado;
     this.logger = logger;
+    this.buildId = "";
     this.dryRun = false;
     this.testRunTitle = "PublishTestPlanResults"
   }
@@ -48,7 +51,7 @@ export class TestRunPublisher {
 
       // create a test run for the project + testPlan using testPoint ids
       const points = Array.from(results.matches.keys());
-      const testRun = await this.ado.createTestRun(projectId, testPlanId, points);
+      const testRun = await this.ado.createTestRun(projectId, testPlanId, points, this.buildId);
       
       // obtain the testcaseresult definitions
       var testCaseResults = await this.ado.getTestResults(projectId, testRun.id);

--- a/PublishTestPlanResultsV1/publishing/TestRunPublisherParameters.ts
+++ b/PublishTestPlanResultsV1/publishing/TestRunPublisherParameters.ts
@@ -1,12 +1,14 @@
 export class TestRunPublisherParameters {
   public accessToken: string;
+  public buildId : string;
   public collectionUri: string;
   public dryRun : boolean;
   public testRunTitle : string;
 
-  constructor(collectionUri: string, accessToken: string, dryRun: boolean, testRunTitle : string) {
+  constructor(collectionUri: string, accessToken: string, dryRun: boolean, testRunTitle : string, buildId : string) {
       this.collectionUri = collectionUri;
       this.accessToken = accessToken;
+      this.buildId = buildId;
       this.dryRun = dryRun;
       this.testRunTitle = testRunTitle;
   }

--- a/PublishTestPlanResultsV1/services/AdoWrapper.ts
+++ b/PublishTestPlanResultsV1/services/AdoWrapper.ts
@@ -111,16 +111,20 @@ export class AdoWrapper {
    * @param projectId project name or identifier
    * @param testPlanId test plan id
    * @param testPoints array of testpoint ids
+   * @param buildId build identifier
    * @returns returns the resulting TestRun from the operation
    */
-  async createTestRun(projectId : string, testPlanId : number, testPoints : number[]) : Promise<Contracts.TestRun> {
-    this.logger.debug(`createTestRun projectId:${projectId} testPlanId:${testPlanId} testPoints: (${testPoints.length} items)`);
-    
+  async createTestRun(projectId : string, testPlanId : number, testPoints : number[], buildId : string) : Promise<Contracts.TestRun> {
+    this.logger.debug(`createTestRun projectId:${projectId} testPlanId:${testPlanId} testPoints: (${testPoints.length} items) - buildId:${buildId}`);
+
     let testRun : Contracts.RunCreateModel = {
       automated: true,
       name: "PublishTestPlanResults",
       plan: <Contracts.ShallowReference>{
         id: testPlanId.toString()
+      },
+      build: <Contracts.ShallowReference>{
+        id: buildId,
       },
       pointIds: testPoints,
       /* this property is required because it's not optional in the typescript def */

--- a/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
+++ b/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
@@ -22,7 +22,6 @@ describe('TaskParameters', () => {
     util.setSystemVariable("System.AccessToken", process.env.SYSTEM_ACCESSTOKEN as string);
     util.setSystemVariable("ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN", process.env.SYSTEM_ACCESSTOKEN as string);
     util.setSystemVariable("System.TeamProject", process.env.TEAMPROJECT as string);
-
   });
 
   afterEach(() => {
@@ -349,6 +348,22 @@ describe('TaskParameters', () => {
       expect(parameters.dryRun).to.be.false;
       expect(parameters.testRunTitle).to.eq("PublishTestPlanResult");
     });
+
+    it('Should resolve build id from build pipeline', () => {
+      // arrange
+      // BUILD_BUILDID is available in build and classic release pipelines.
+      // for release pipelines, if there are multiple build artifacts, the build id is 
+      // based on the primary artifact.
+      util.setSystemVariable("BUILD_BUILDID", "1234")
+      util.loadData();
+
+      // act
+      require(tp);
+      var parameters = TaskParameters.getPublisherParameters();
+
+      // assert
+      expect(parameters.buildId).to.eq("1234");
+    })
 
     it("Should allow testRun publishing to be disabled by enabling 'dryRun'", () => {
       // arrange

--- a/PublishTestPlanResultsV1/test/TestRunPublisher.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestRunPublisher.specs.ts
@@ -58,8 +58,9 @@ context("TestRunPublisher", () => {
       this.timeout(10000);
       const serverUrl = process.env.SYSTEM_COLLECTIONURI as string;
       const accessToken = (process.env.SYSTEM_ACCESSTOKEN ?? process.env.ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN) as string;
+      const buildId = "123";
       console.log(serverUrl);
-      var parameters = new TestRunPublisherParameters(serverUrl, accessToken, false, "Dummy");
+      var parameters = new TestRunPublisherParameters(serverUrl, accessToken, false, "Dummy", buildId);
 
       // act
       var subject = await TestRunPublisher.create(parameters);
@@ -67,6 +68,8 @@ context("TestRunPublisher", () => {
       // assert
       expect(subject).not.to.be.undefined;
       expect(subject.dryRun).eq(false);
+      expect(subject.testRunTitle).eq("Dummy");
+      expect(subject.buildId).eq("123");
     })
 
   })

--- a/PublishTestPlanResultsV1/test/testUtil.ts
+++ b/PublishTestPlanResultsV1/test/testUtil.ts
@@ -22,7 +22,8 @@ export function clearData() {
   Object.keys(process.env)
     .filter(key => (key.startsWith('INPUT_') ||
       key.startsWith("SECRET_") ||
-      key.startsWith("VSTS_TASKVARIABLE_")
+      key.startsWith("VSTS_TASKVARIABLE_") ||
+      key.startsWith("BUILD_")
     )
     ).forEach(key => delete process.env[key]);
 }


### PR DESCRIPTION
As per suggestion by @sinanmetin in #45, the `$(Build.BuildId)` of the active build is attached to the TestRun. This will display the `$(Build.BuildNumber)` as set by the BuildId.