### PR TITLE
Fix for relative file paths from testResultDirectory

### DIFF
--- a/PublishTestPlanResultsV1/Test-ExtensionLocally.ps1
+++ b/PublishTestPlanResultsV1/Test-ExtensionLocally.ps1
@@ -90,6 +90,10 @@ if ($BuildId) {
   [System.Environment]::SetEnvironmentVariable("BUILD_BUILDID", $BuildId)
 }
 
+if (!$env:SYSTEM_DEFAULTWORKINGDIRECTORY) {
+  [System.Environment]::SetEnvironmentVariable("SYSTEM_DEFAULTWORKINGDIRECTORY", (Resolve-Path .))
+}
+
 
 if ($DebugMode.IsPresent) {
   [System.Environment]::SetEnvironmentVariable("SYSTEM_DEBUG", "true");

--- a/PublishTestPlanResultsV1/task.json
+++ b/PublishTestPlanResultsV1/task.json
@@ -112,7 +112,7 @@
         },
         {
             "name": "testResultFiles",
-            "type": "filePath",
+            "type": "string",
             "required": true,
             "label": "Test Result Files",
             "groupName": "general",

--- a/PublishTestPlanResultsV1/test/testUtil.ts
+++ b/PublishTestPlanResultsV1/test/testUtil.ts
@@ -25,6 +25,7 @@ export function clearData() {
       key.startsWith("VSTS_TASKVARIABLE_") ||
       key.startsWith("BUILD_")
     )
+    // caution: System_* variables should not be deleted
     ).forEach(key => delete process.env[key]);
 }
 


### PR DESCRIPTION
This PR fixes #50, which changes the way file paths are resolved.

Files are now resolved relative to the `testResultDirectory` unless they are absolute paths. This required a minor change to the data-type used for the `testResultFiles` input parameter from `filepath` to `string`.  For YAML users, there is no noticeable change, however, individuals using the Classic Build editor will not get automatic file resolution in the user-interface.

The `testResultDirectory` defaults to `$(System.DefaultWorkingDirectory)` which resolves to different locations, depending whether the task is executing in a build or Classic Release pipeline:

- For [Build pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#system-variables-devops-services), `$(System.DefaultWorkingDirectory)` aliases to `$(Build.SourcesDirectory)`
- For [Designer (aka "Classic") Release pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/variables?view=azure-devops&tabs=batch#system-variables) `$(System.DefaultWorkingDirectory)` aliases to `$(System.ArtifactsDirectory)`