### PR TITLE
New "vsproperty" match strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vs
+bin
+obj

--- a/PublishTestPlanResultsV1/processing/TestResultMatchStrategy.ts
+++ b/PublishTestPlanResultsV1/processing/TestResultMatchStrategy.ts
@@ -6,9 +6,9 @@ export enum TestCaseMatchingStrategy {
   name = 2,
   regex = 4,
   property = 8,
-  //vsproperty = 16,
+  vsproperty = 16,
 
-  auto = 2 + 4 + 8
+  auto = 2 + 4 + 8 + 16
 }
 
 export enum TestResultMatch {

--- a/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
+++ b/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
@@ -87,7 +87,7 @@ export class TestNameMatchStrategy implements TestResultMatchStrategy {
 
   isMatch( result : TestFrameworkResult, point : TestPoint) : TestResultMatch {
     
-    if (this.simplify(result.name) == this.simplify((point as TestPoint2).testCaseReference.name!)) {
+    if (this.simplify(result.name).endsWith(this.simplify((point as TestPoint2).testCaseReference.name!))) {
       return TestResultMatch.Exact;
     }
 

--- a/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
+++ b/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
@@ -22,9 +22,9 @@ export function create( parameters : TestResultProcessorParameters, context : Te
   }
 
   // match if the test automation property is present, allow pass thru
-  // if (parameters.testCaseMatchStrategy & TestCaseMatchingStrategy.vsproperty) {
-  //   matchers.push(new TestAutomationPropertyMatchStrategy());
-  // }
+  if (parameters.testCaseMatchStrategy & TestCaseMatchingStrategy.vsproperty) {
+    matchers.push(new TestAutomationPropertyMatchStrategy());
+  }
 
   // match if the test id appears in a regex, allow pass thru
   if (parameters.testCaseMatchStrategy & TestCaseMatchingStrategy.regex) {
@@ -125,20 +125,28 @@ export class TestRegexMatchStrategy implements TestResultMatchStrategy {
 
 export const TestCaseAutomationProperty : string = "Microsoft.VSTS.TCM.AutomatedTestName";
 
-// export class TestAutomationPropertyMatchStrategy implements TestResultMatchStrategy {
+export class TestAutomationPropertyMatchStrategy implements TestResultMatchStrategy {
 
-//   isMatch(result: TestFrameworkResult, point: TestPoint): TestResultMatch {
-//     // get test automation property from testpoint
-//     point.workItemProperties
-//     // if automation property is present
-//       // do fuzzy match on framework result
-//       // if no match, fail
-//     // if not present
-//     // allow pass-thru
-//     throw new Error("Method not implemented");
-//   }
+  isMatch(result: TestFrameworkResult, point: TestPoint): TestResultMatch {
 
-// }
+    // get test automation property from testpoint
+    if (point.workItemProperties && point.workItemProperties.length > 0) {
+      let automatedTestName = this.getAutomationProperty(point);
+      if (automatedTestName) {
+        return result.name.toLowerCase() == automatedTestName.toLowerCase() ?
+          TestResultMatch.Exact : TestResultMatch.Fail;
+      }
+    }
+    // if not present, pass-thru
+    return TestResultMatch.None;
+  }
+
+  private getAutomationProperty(point : TestPoint) : string | undefined {
+    let property = point.workItemProperties.find( i => i[TestCaseAutomationProperty] != undefined);
+    return property ? property[TestCaseAutomationProperty] : undefined;
+  }
+
+}
 
 export class TestIdMatchStrategy implements TestResultMatchStrategy {
 
@@ -158,7 +166,7 @@ export class TestIdMatchStrategy implements TestResultMatchStrategy {
     }
 
     // this should be the end of the line if we haven't matched already
-    return TestResultMatch.Fail;
+    return TestResultMatch.Fail; // TODO: switch to None and introduce NonMatchStrategy
   }
 }
 

--- a/PublishTestPlanResultsV1/test/AdoWrapper.specs.ts
+++ b/PublishTestPlanResultsV1/test/AdoWrapper.specs.ts
@@ -107,6 +107,16 @@ describe("AdoWrapper", () => {
       // assert
       expect(result.length).greaterThan(0);
     });
+
+    it("Should fetch all test cases in a testplan", async function () {
+      // arrange
+      this.timeout(10000);
+      // act
+      var result = await subject.getTestCasesForSuite(projectId, planId, rootSuite, true);
+
+      // assert
+      expect(result.length).greaterThan(0);
+    })
   })  
 
   // unit test / stub out rest get
@@ -138,6 +148,15 @@ describe("AdoWrapper", () => {
     // assert
     expect(result.length).eq(20);
   });
+
+  it("Should paginate to fetch all test cases", async function () {
+    // arrange
+    stubGetRequestWithContinuationToken("Test Case"); // paginate 10 results x2
+    // act
+    var result = await subject.getTestCasesForSuite(projectId, planId, rootSuite, true);
+    // assert
+    expect(result.length).eq(20);
+  })
 
   // it("Should create a testrun", async function () {
   //   // arrange

--- a/PublishTestPlanResultsV1/test/TestResultMatchStrategy.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestResultMatchStrategy.specs.ts
@@ -135,6 +135,17 @@ describe("TestCaseMatchStrategy", () => {
       expect(result).to.eq(TestResultMatch.Exact);
     });
 
+    it("Should compare the test method to the testcase name", () => {
+      // arrange
+      test = new TestFrameworkResult("Namespace.ClassName.The_Name_Of_The_Test", "FAIL");
+
+      // act
+      var result = subject.isMatch(test, point);
+
+      // assert
+      expect(result).to.eq(TestResultMatch.Exact);  
+    })
+
     it("Should treat non-matches as neutral matches to allow further filtering", () => {
       // arrange
       test = new TestFrameworkResult("Not the same name", "FAIL");

--- a/PublishTestPlanResultsV1/test/TestResultProcessorFactory.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestResultProcessorFactory.specs.ts
@@ -24,7 +24,7 @@ describe('TestResultProcessorFactory', () => {
     var result = subject.create(parameters, ctx);
 
     // assert
-    expect(result.matchers.length).to.eq(4);
+    expect(result.matchers.length).to.eq(5);
   });
 
   it('Should configure only name matcher when set to name', async () => {
@@ -60,16 +60,14 @@ describe('TestResultProcessorFactory', () => {
     expect(result.matchers.length).to.eq(2); /* config filter is always present */
   });
 
-  // it('Should configure only vsprop matcher when set to vsproperty', async () => {
-  //   // arrange
-  //   parameters = new TestResultProcessorParameters("vsproperty");
+  it('Should configure only vsprop matcher when set to vsproperty', async () => {
+    // arrange
+    parameters = new TestResultProcessorParameters("vsproperty");
 
-  //   // act
-  //   var result = subject.create(parameters, ctx);
+    // act
+    var result = subject.create(parameters, ctx);
 
-  //   // assert
-  //   expect(result.matchers.length).to.eq(2); /* config filter is always present */
-  // });
-  
-
+    // assert
+    expect(result.matchers.length).to.eq(2); /* config filter is always present */
+  });
 })

--- a/PublishTestPlanResultsV1/test/testUtil.ts
+++ b/PublishTestPlanResultsV1/test/testUtil.ts
@@ -1,6 +1,6 @@
 import im = require('azure-pipelines-task-lib/internal');
 import * as assert from 'assert'
-import { ShallowReference, TestPlan, TestConfiguration, WorkItemReference } from 'azure-devops-node-api/interfaces/TestInterfaces';
+import { ShallowReference, TestPlan, TestConfiguration, WorkItemReference, SuiteTestCase } from 'azure-devops-node-api/interfaces/TestInterfaces';
 import { TestPoint2 } from '../services/AdoWrapper';
 import { TestFrameworkResult } from '../framework/TestFrameworkResult';
 
@@ -85,6 +85,33 @@ export function newTestPoint(id : number = 0, name : string = "Test 1", configId
     },
     configuration: newShallowReference(configId, configId)
   };
+}
+
+export function newTestCase(testCaseId: string, fields: workItemField[]) {
+  let testCase = {
+    // only return the fields that are needed
+    workItem: {
+      id: testCaseId,
+      workItemFields: <any>[]
+    }
+  }
+  fields.forEach(field => {
+    let item = <any>{ };
+    item[field.referenceName] = field.value;
+
+    testCase.workItem.workItemFields.push(item);
+  })
+  return testCase;
+}
+
+export class workItemField {
+  referenceName: string;
+  value: string;
+
+  constructor(referenceName: string, value: string) {
+    this.referenceName = referenceName;
+    this.value = value;
+  }
 }
 
 export function newShallowReference(id : string, name : string) {

--- a/examples/dotnet/xUnitExample/README.md
+++ b/examples/dotnet/xUnitExample/README.md
@@ -1,0 +1,36 @@
+# xUnit Example
+
+This basic xUnit Test Project produces an XML file in xUnit format that can be published to a Test Plan.
+
+A sample of the XML output file is included for reference.
+
+## Environment
+
+This project is written with the following:
+
+- .NET 8
+- xUnit (2.9.2)
+- xUnit.Runner (2.8.2)
+- xUnitXml.Logger (4.1.0)
+
+## Usage
+
+To run the tests and produce the Xml output:
+
+```shell
+dotnet restore
+dotnet test --logger:xunit
+```
+
+To publish xUnit results to a test plan, the following pipeline syntax matches the referenced examples:
+
+```yaml
+- task: PublishTestPlanResults@1
+  inputs:
+    testResultsFiles: 'path/to/TestResults.xml'
+    testResultFormat: xunit
+    testPlan: 'Your Test Plan'
+    testCaseMatchStrategy: auto    # this is the default value
+    testCaseProperty: TestCaseId   # because the tests are using [Trait("TestCaseId", ...)]
+    testCaseRegex: 'TestCase(\d+)' # because the tests use a naming convention of '<testname>_TestCaseNNN'
+```

--- a/examples/dotnet/xUnitExample/TestResults/TestResults.xml
+++ b/examples/dotnet/xUnitExample/TestResults/TestResults.xml
@@ -1,0 +1,43 @@
+<assemblies timestamp="11/24/2024 02:27:13">
+  <assembly name="C:\dev\code\_Personal\testplan-extension\examples\dotnet\xUnitExample\bin\Debug\net8.0\xUnitExample.dll" run-date="2024-11-24" run-time="02:27:13" total="9" passed="7" failed="1" skipped="1" time="2.996" errors="0">
+    <errors />
+    <collection total="9" passed="7" failed="1" skipped="1" name="Test collection for xUnitExample.MatchStrategyExamples" time="0.225">
+      <test name="Match Test Case by Display Name" type="xUnitExample.MatchStrategyExamples" method="Match_TestCaseByDisplayNameInsteadOfMethodName" time="0.0016537" result="Pass">
+        <traits />
+      </test>
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName2" type="xUnitExample.MatchStrategyExamples" method="xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName2" time="0.0000412" result="Pass">
+        <traits />
+      </test>
+      <test name="xUnitExample.MatchStrategyExamples.Match_Test_Case_By_Exact_Name" type="xUnitExample.MatchStrategyExamples" method="Match_Test_Case_By_Exact_Name" time="0.0000230" result="Pass">
+        <traits />
+      </test>
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_TestMethod_AssociatedToTestCase_Using_Trait" type="xUnitExample.MatchStrategyExamples" method="xUnit_TestMethod_AssociatedToTestCase_Using_Trait" time="0.0000195" result="Pass">
+        <traits>
+          <trait name="TestCaseId" value="1234" />
+        </traits>
+      </test>
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName1" type="xUnitExample.MatchStrategyExamples" method="xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName1" time="0.0000183" result="Pass">
+        <traits />
+      </test>
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_FailingTest_TestCase4824" type="xUnitExample.MatchStrategyExamples" method="xUnit_FailingTest_TestCase4824" time="0.2216918" result="Fail">
+        <failure>
+          <message>This test failed intentionally</message>
+          <stack-trace>   at xUnitExample.MatchStrategyExamples.xUnit_FailingTest_TestCase4824() in C:\dev\code\_Personal\testplan-extension\examples\dotnet\xUnitExample\UnitTest1.cs:line 19
+   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
+   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)</stack-trace>
+        </failure>
+        <traits />
+      </test>
+      <test name="xUnitExample.MatchStrategyExamples.match_TEST_case_By_Exact_Name_CaSe_iNsEnSiTiVe" type="xUnitExample.MatchStrategyExamples" method="match_TEST_case_By_Exact_Name_CaSe_iNsEnSiTiVe" time="0.0000500" result="Pass">
+        <traits />
+      </test>
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_PassingTest_TestCase4823" type="xUnitExample.MatchStrategyExamples" method="xUnit_PassingTest_TestCase4823" time="0.0000266" result="Pass">
+        <traits />
+      </test>
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_SkippedTest_TestCase4825" type="xUnitExample.MatchStrategyExamples" method="xUnit_SkippedTest_TestCase4825" time="0.0010000" result="Skip">
+        <reason><![CDATA[This test is skipped and is recorded as 'NotExecuted' in the Test Run]]></reason>
+        <traits />
+      </test>
+    </collection>
+  </assembly>
+</assemblies>

--- a/examples/dotnet/xUnitExample/TestResults/TestResults.xml
+++ b/examples/dotnet/xUnitExample/TestResults/TestResults.xml
@@ -1,25 +1,25 @@
-<assemblies timestamp="11/24/2024 02:27:13">
-  <assembly name="C:\dev\code\_Personal\testplan-extension\examples\dotnet\xUnitExample\bin\Debug\net8.0\xUnitExample.dll" run-date="2024-11-24" run-time="02:27:13" total="9" passed="7" failed="1" skipped="1" time="2.996" errors="0">
+<assemblies timestamp="11/24/2024 16:09:58">
+  <assembly name="C:\dev\code\_Personal\testplan-extension\examples\dotnet\xUnitExample\bin\Debug\net8.0\xUnitExample.dll" run-date="2024-11-24" run-time="16:09:58" total="9" passed="7" failed="1" skipped="1" time="3.510" errors="0">
     <errors />
-    <collection total="9" passed="7" failed="1" skipped="1" name="Test collection for xUnitExample.MatchStrategyExamples" time="0.225">
-      <test name="Match Test Case by Display Name" type="xUnitExample.MatchStrategyExamples" method="Match_TestCaseByDisplayNameInsteadOfMethodName" time="0.0016537" result="Pass">
+    <collection total="9" passed="7" failed="1" skipped="1" name="Test collection for xUnitExample.MatchStrategyExamples" time="0.377">
+      <test name="Match Test Case by Display Name" type="xUnitExample.MatchStrategyExamples" method="Match_TestCaseByDisplayNameInsteadOfMethodName" time="0.0019464" result="Pass">
         <traits />
       </test>
-      <test name="xUnitExample.MatchStrategyExamples.xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName2" type="xUnitExample.MatchStrategyExamples" method="xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName2" time="0.0000412" result="Pass">
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName2" type="xUnitExample.MatchStrategyExamples" method="xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName2" time="0.0000466" result="Pass">
         <traits />
       </test>
-      <test name="xUnitExample.MatchStrategyExamples.Match_Test_Case_By_Exact_Name" type="xUnitExample.MatchStrategyExamples" method="Match_Test_Case_By_Exact_Name" time="0.0000230" result="Pass">
+      <test name="xUnitExample.MatchStrategyExamples.Match_Test_Case_By_Exact_Name" type="xUnitExample.MatchStrategyExamples" method="Match_Test_Case_By_Exact_Name" time="0.0000248" result="Pass">
         <traits />
       </test>
-      <test name="xUnitExample.MatchStrategyExamples.xUnit_TestMethod_AssociatedToTestCase_Using_Trait" type="xUnitExample.MatchStrategyExamples" method="xUnit_TestMethod_AssociatedToTestCase_Using_Trait" time="0.0000195" result="Pass">
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_TestMethod_AssociatedToTestCase_Using_Trait" type="xUnitExample.MatchStrategyExamples" method="xUnit_TestMethod_AssociatedToTestCase_Using_Trait" time="0.0000188" result="Pass">
         <traits>
-          <trait name="TestCaseId" value="1234" />
+          <trait name="TestCaseId" value="4831" />
         </traits>
       </test>
-      <test name="xUnitExample.MatchStrategyExamples.xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName1" type="xUnitExample.MatchStrategyExamples" method="xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName1" time="0.0000183" result="Pass">
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName1" type="xUnitExample.MatchStrategyExamples" method="xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName1" time="0.0000186" result="Pass">
         <traits />
       </test>
-      <test name="xUnitExample.MatchStrategyExamples.xUnit_FailingTest_TestCase4824" type="xUnitExample.MatchStrategyExamples" method="xUnit_FailingTest_TestCase4824" time="0.2216918" result="Fail">
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_FailingTest_TestCase4824" type="xUnitExample.MatchStrategyExamples" method="xUnit_FailingTest_TestCase4824" time="0.3738902" result="Fail">
         <failure>
           <message>This test failed intentionally</message>
           <stack-trace>   at xUnitExample.MatchStrategyExamples.xUnit_FailingTest_TestCase4824() in C:\dev\code\_Personal\testplan-extension\examples\dotnet\xUnitExample\UnitTest1.cs:line 19
@@ -28,10 +28,10 @@
         </failure>
         <traits />
       </test>
-      <test name="xUnitExample.MatchStrategyExamples.match_TEST_case_By_Exact_Name_CaSe_iNsEnSiTiVe" type="xUnitExample.MatchStrategyExamples" method="match_TEST_case_By_Exact_Name_CaSe_iNsEnSiTiVe" time="0.0000500" result="Pass">
+      <test name="xUnitExample.MatchStrategyExamples.match_TEST_case_By_Exact_Name_CaSe_iNsEnSiTiVe" type="xUnitExample.MatchStrategyExamples" method="match_TEST_case_By_Exact_Name_CaSe_iNsEnSiTiVe" time="0.0000727" result="Pass">
         <traits />
       </test>
-      <test name="xUnitExample.MatchStrategyExamples.xUnit_PassingTest_TestCase4823" type="xUnitExample.MatchStrategyExamples" method="xUnit_PassingTest_TestCase4823" time="0.0000266" result="Pass">
+      <test name="xUnitExample.MatchStrategyExamples.xUnit_PassingTest_TestCase4823" type="xUnitExample.MatchStrategyExamples" method="xUnit_PassingTest_TestCase4823" time="0.0000304" result="Pass">
         <traits />
       </test>
       <test name="xUnitExample.MatchStrategyExamples.xUnit_SkippedTest_TestCase4825" type="xUnitExample.MatchStrategyExamples" method="xUnit_SkippedTest_TestCase4825" time="0.0010000" result="Skip">

--- a/examples/dotnet/xUnitExample/UnitTest1.cs
+++ b/examples/dotnet/xUnitExample/UnitTest1.cs
@@ -1,0 +1,81 @@
+namespace xUnitExample
+{
+
+  public class MatchStrategyExamples
+  {
+    // These test demonstrate using the
+    // regex match strategy, where the TestCase
+    // number appears in the test method name.
+    // The `testCaseRegex` input is set to: 'TestCase(\d+)'
+    #region Match Strategy: regex
+    [Fact]
+    public void xUnit_PassingTest_TestCase4823()
+    {
+    }
+
+    [Fact]
+    public void xUnit_FailingTest_TestCase4824()
+    {
+      Assert.Fail("This test failed intentionally");
+    }
+
+    [Fact(Skip = "This test is skipped and is recorded as 'NotExecuted' in the Test Run")]
+    public void xUnit_SkippedTest_TestCase4825()
+    {
+    }
+    #endregion
+
+    // These test demonstrate using the 
+    // "name" match strategy, where the display name
+    // of the test method is an equivalent match for
+    // the TestCase name in the Test Plan.
+    #region Match Strategy: name
+    [Fact]
+    public void Match_Test_Case_By_Exact_Name()
+    {
+    }
+
+    [Fact]
+    public void match_TEST_case_By_Exact_Name_CaSe_iNsEnSiTiVe()
+    {
+    }
+
+    [Fact(DisplayName = "Match Test Case by Display Name")]
+    public void Match_TestCaseByDisplayNameInsteadOfMethodName()
+    {
+    }
+    #endregion
+
+    // These tests demonstrate using the
+    // "vsproperty" match strategy, where each of these
+    // test methods have been associated with a TestCase
+    // in the TestPlan by setting the fully qualified
+    // method name as the "Automated Test Name" 
+    // (Microsoft.VSTS.TCM.TestAutomatedName) using
+    // Visual Studio as described in:
+    // https://learn.microsoft.com/en-us/azure/devops/test/associate-automated-test-with-test-case?view=azure-devops#associate-your-test
+    #region Match Strategy: vstest
+    [Fact]
+    public void xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName1()
+    {
+    }
+
+    [Fact]
+    public void xUnit_TestMethod_AssociatedToTestCase_Using_Microsoft_VSTS_TCM_TestAutomatedName2()
+    {
+    }
+    #endregion
+
+    // These test cases demonstrate using the
+    // "property" match strategy, where the TestCase
+    // number appears in a xUnit Trait attribute.
+    // The `testCaseProperty` input is set to 'TestCaseId'
+    #region Match Strategy: property
+    [Fact]
+    [Trait("TestCaseId", "1234")]
+    public void xUnit_TestMethod_AssociatedToTestCase_Using_Trait()
+    {
+    }
+    #endregion
+  }
+}

--- a/examples/dotnet/xUnitExample/UnitTest1.cs
+++ b/examples/dotnet/xUnitExample/UnitTest1.cs
@@ -72,7 +72,7 @@ namespace xUnitExample
     // The `testCaseProperty` input is set to 'TestCaseId'
     #region Match Strategy: property
     [Fact]
-    [Trait("TestCaseId", "1234")]
+    [Trait("TestCaseId", "4831")]
     public void xUnit_TestMethod_AssociatedToTestCase_Using_Trait()
     {
     }

--- a/examples/dotnet/xUnitExample/xUnitExample.csproj
+++ b/examples/dotnet/xUnitExample/xUnitExample.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="XunitXml.TestLogger" Version="4.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/examples/dotnet/xUnitExample/xUnitExample.sln
+++ b/examples/dotnet/xUnitExample/xUnitExample.sln
@@ -1,0 +1,30 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35201.131
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xUnitExample", "xUnitExample.csproj", "{5173121C-A90E-4ECB-A672-26785D20A87F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{730F9E6E-1F48-4A08-91E8-3FAE81AA7B68}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5173121C-A90E-4ECB-A672-26785D20A87F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5173121C-A90E-4ECB-A672-26785D20A87F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5173121C-A90E-4ECB-A672-26785D20A87F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5173121C-A90E-4ECB-A672-26785D20A87F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0941952E-4D9B-480D-816C-BB39AD6BDE46}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This PR introduces support for the "vsproperty" match strategy that fetches work item meta data for each TestCase and compares the test name to the _Microsoft.VSTS.TCM.AutomatedTestName_ field.

Resolves #20, #59