### PR TITLE
Fix for multi-configuration support

### DIFF
--- a/PublishTestPlanResultsV1/processing/TestResultProcessor.ts
+++ b/PublishTestPlanResultsV1/processing/TestResultProcessor.ts
@@ -2,6 +2,7 @@ import { TestPoint, TestPlan } from "azure-devops-node-api/interfaces/TestInterf
 import { TestResultContext } from "../context/TestResultContext";
 import { TestFrameworkResult } from "../framework/TestFrameworkResult";
 import { TestResultMatch, TestResultMatchStrategy } from "./TestResultMatchStrategy";
+import { JSONStringify } from "../services/JsonUtil";
 import { ILogger, getLogger } from "../services/Logger"
 
 export class TestResultProcessorResult {
@@ -43,7 +44,7 @@ export class TestResultProcessor {
         break;
       }
 
-      this.logger.debug(`evaluating '${frameworkResult.name}' (${JSON.stringify(frameworkResult)})`);
+      this.logger.debug(`evaluating '${frameworkResult.name}' (${JSONStringify(frameworkResult)})`);
 
       let matchingPoints = testPoints.filter(point => this.compare(frameworkResult, point));
 

--- a/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
+++ b/PublishTestPlanResultsV1/processing/TestResultProcessorFactory.ts
@@ -72,7 +72,7 @@ export class TestConfigMatchStrategy implements TestResultMatchStrategy {
       let configIdToCompare = this.allowedConfigs.get(testResultConfig)?.id?.toString();
 
       // compare against the test point
-      if (configIdToCompare !== point.configuration.id) {
+      if (configIdToCompare !== point.configuration.id?.toString()) {
         return TestResultMatch.Fail;
       }
     }

--- a/PublishTestPlanResultsV1/services/JsonUtil.ts
+++ b/PublishTestPlanResultsV1/services/JsonUtil.ts
@@ -1,0 +1,13 @@
+function jsonStringifyReplacer(key: string, value: any) {
+  if (value instanceof Map) {
+    return Object.fromEntries(value);
+  }
+  if (Array.isArray(value)) {
+    return [...value];
+  }
+  return value;
+}
+
+export function JSONStringify(obj: any): string {
+  return JSON.stringify(obj, jsonStringifyReplacer);
+}

--- a/PublishTestPlanResultsV1/test/JsonUtil.specs.ts
+++ b/PublishTestPlanResultsV1/test/JsonUtil.specs.ts
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import path from "path";
+import * as Contracts from 'azure-devops-node-api/interfaces/TestInterfaces'
+import { TestFrameworkResult } from "../framework/TestFrameworkResult";
+import { JSONStringify } from "../services/JsonUtil";
+
+
+
+describe("JSONUtil", () => {
+
+  let resultItem: TestFrameworkResult
+
+  beforeEach(() => {
+    resultItem = new TestFrameworkResult("TestName", "PASS")
+    resultItem.duration = 1234.5678
+    resultItem.stacktrace = "stacktrace"
+    resultItem.failure = "failure"
+  });
+
+  it("Can stringify test framework result", () => {
+    // arrange
+    // act
+    const result = JSONStringify(resultItem);
+
+    // assert
+    expect(result).to.contain('"name":"TestName"');
+    expect(result).to.contain('"duration":1234.5678');
+    expect(result).to.contain('"stacktrace":"stacktrace"');
+    expect(result).to.contain('"failure":"failure"');
+    expect(result).to.contain('"outcome":2');
+    expect(result).to.contain('"properties":{}');
+    expect(result).to.contain('"attachments":[]');
+  });
+
+  it("Can stringify test framework result with properties", () => {
+    // arrange
+    resultItem.properties.set("TestID", "1234")
+    resultItem.properties.set("TestConfig", "edge")
+
+    // act
+    const result = JSONStringify(resultItem);
+
+    // assert
+    expect(result).to.contain('"properties":{"TestID":"1234","TestConfig":"edge"}');
+  });
+
+  it("Can stringify test framework result with attachments", () => {
+    // arrange
+    resultItem.attachments.push({ name: "TestAttachment", path: "filepath1" })
+    resultItem.attachments.push({ name: "TestAttachment2", path: "filepath2" })
+
+    // act
+    const result = JSONStringify(resultItem);
+
+    // assert
+    expect(result).to.contain('"attachments":[{"name":"TestAttachment","path":"filepath1"},{"name":"TestAttachment2","path":"filepath2"}]');
+  });
+
+});

--- a/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
@@ -103,6 +103,18 @@ describe("TestFramework Results Reader", () => {
     expect(results[0].duration).to.eq(10000);
   });
 
+  // https://github.com/bryanbcook/azdevops-testplan-extension/issues/92
+  it("Can read JUnit properties", async () => {
+    // arrange
+    files.push(path.join(baseDir, "junit/bug-92.xml"));
+    
+    // act
+    var results = await subject.read("junit", files);
+
+    // assert
+    expect(results[0].properties.size).to.eq(3);
+  });
+
   it("Can read Cucumber results", async () => {
     // arrange
     files.push(path.join(baseDir, "cucumber/single-suite-single-test.json"));

--- a/PublishTestPlanResultsV1/test/data/junit/bug-92.xml
+++ b/PublishTestPlanResultsV1/test/data/junit/bug-92.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testsuite name="pytest" errors="0" failures="0" skipped="0" tests="6" time="271.885" timestamp="2025-05-06T17:11:00.804626-04:00" hostname="ROM-1GLRCX3">
+    <testcase classname="tests.test_menu_elements" name="Test Menu Elements" time="11.656">
+      <properties>
+        <property name="TestConfig" value="chromium" />
+        <property name="TestId" value="8207" />
+      </properties>
+    </testcase>
+    <testcase classname="tests.test_menu_elements" name="Test Menu Elements" time="235.515">
+      <properties>
+        <property name="TestConfig" value="firefox" />
+        <property name="TestId" value="8207" />
+      </properties>
+    </testcase>
+    <testcase classname="tests.test_menu_elements" name="Test Menu Elements" time="5.432">
+      <properties>
+        <property name="TestConfig" value="edge" />
+        <property name="TestId" value="8207" />
+      </properties>
+    </testcase>
+    <testcase classname="tests.test_admin_tab" name="Test Admin Tab" time="5.243">
+      <properties>
+        <property name="TestConfig" value="chromium" />
+        <property name="TestId" value="8173" />
+      </properties>
+    </testcase>
+    <testcase classname="tests.test_admin_tab" name="Test Admin Tab" time="8.711">
+      <properties>
+        <property name="TestConfig" value="firefox" />
+        <property name="TestId" value="8173" />
+      </properties>
+    </testcase>
+    <testcase classname="tests.test_admin_tab" name="Test Admin Tab" time="5.310">
+      <properties>
+        <property name="TestConfig" value="edge" />
+        <property name="TestId" value="8173" />
+      </properties>
+    </testcase>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
This PR addresses #92 where all `TestPoints` were excluded from consideration due to a type-coercion issue.

The contract defines a [`ShallowReference`][1] with an "id" property of type string, but it seems the API is returning a number. 

This PR also includes:

- Fixes for unit tests to ensure this area of the code is properly covered
- Extra detail in the JSON payload to show properties and attachments in the debug logs.

[1]: https://github.com/microsoft/azure-devops-node-api/blob/1d8f29c52c10a1fa875b04c9add5198ef1db54a2/api/interfaces/TestInterfaces.ts#L2385