### PR TITLE
Updated testparser 0.2.6 - add support for jUnit property syntax

### DIFF
--- a/PublishTestPlanResultsV1/package-lock.json
+++ b/PublishTestPlanResultsV1/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "azure-devops-node-api": "^12.5.0",
         "azure-pipelines-task-lib": "^4.17.1",
-        "test-results-parser": "0.2.5"
+        "test-results-parser": "0.2.6"
       },
       "devDependencies": {
         "@types/chai": "^5.2.2",
@@ -1005,9 +1005,9 @@
       }
     },
     "node_modules/test-results-parser": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/test-results-parser/-/test-results-parser-0.2.5.tgz",
-      "integrity": "sha512-hCrquOqISLzPOj9YST/4s5tLX0d5kOKIlbpmQ0DzsVZz2ag83ZBp/H637jZh6Endjqrg1MjsEYfHMCGM5uzvhQ==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/test-results-parser/-/test-results-parser-0.2.6.tgz",
+      "integrity": "sha512-jGK1jqr42knYI4UZgRM7PZKNjgjOon79EFrThhXx1LPeRJAjEkZgLt3hGHHFXUNM8PLN/uT2iyiibYnev7IlWA==",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^4.4.1",

--- a/PublishTestPlanResultsV1/package.json
+++ b/PublishTestPlanResultsV1/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "azure-devops-node-api": "^12.5.0",
     "azure-pipelines-task-lib": "^4.17.1",
-    "test-results-parser": "0.2.5"
+    "test-results-parser": "0.2.6"
   },
   "devDependencies": {
     "@types/chai": "^5.2.2",

--- a/devops/pipelines/marketplace-extension/pipeline.yml
+++ b/devops/pipelines/marketplace-extension/pipeline.yml
@@ -26,9 +26,9 @@ parameters:
   - name: NUnitExample-Attachments
     format: nunit
     testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/NUnitExample-Attachments/TestResults/TestResults.xml'
-  - name: XUnitExample
+  - name: xUnitExample
     format: xunit
-    testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/XUnitExample/TestResults/TestResults.xml'
+    testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/xUnitExample/TestResults/TestResults.xml'
 
 variables:
 - group: pipeline-extension-settings
@@ -144,6 +144,7 @@ jobs:
   - ${{ if or( eq(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranchName'], 'main') ) }}:
     - publish: $(workingDir)
       artifact: 'build'
+      displayName: 'Publish compiled build for regression tests'
 
 # For pull requests or non-main branches, run the regression test suite
 - ${{ if or( eq(variables['Build.Reason'], 'PullRequest'), ne(variables['Build.SourceBranchName'], 'main') ) }}:

--- a/devops/pipelines/marketplace-extension/pipeline.yml
+++ b/devops/pipelines/marketplace-extension/pipeline.yml
@@ -19,7 +19,7 @@ parameters:
   default:
   - name: MSTestExample-Attachments
     format: mstest
-    testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/MSTestExample-Attachments/TestResults/TestResults.xml'
+    testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/MSTestExample-Attachments/TestResults/TestResults.trx'
   - name: NUnitExample
     format: nunit
     testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/NUnitExample/TestResults/TestResults.xml'

--- a/devops/pipelines/marketplace-extension/pipeline.yml
+++ b/devops/pipelines/marketplace-extension/pipeline.yml
@@ -14,6 +14,22 @@ parameters:
   displayName: 'Publish Extension'
   default: false
 
+- name: regressionTests
+  type: object
+  default:
+  - name: MSTestExample-Attachments
+    format: mstest
+    testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/MSTestExample-Attachments/TestResults/TestResults.xml'
+  - name: NUnitExample
+    format: nunit
+    testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/NUnitExample/TestResults/TestResults.xml'
+  - name: NUnitExample-Attachments
+    format: nunit
+    testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/NUnitExample-Attachments/TestResults/TestResults.xml'
+  - name: XUnitExample
+    format: xunit
+    testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/XUnitExample/TestResults/TestResults.xml'
+
 variables:
 - group: pipeline-extension-settings
 - name: workingDir
@@ -141,6 +157,7 @@ jobs:
         node20:
           AGENT_USE_NODE20: true
           nodeVersion: '20.x'
+      
           
     steps:
     - checkout: self
@@ -157,26 +174,27 @@ jobs:
       artifact: 'build'
 
     # run tests
-    - task: PowerShell@2
-      displayName: 'Run extension against NUnit Example'
-      inputs:
-        workingDirectory: $(Pipeline.Workspace)/build
-        filePath: '$(Pipeline.Workspace)/build/Test-ExtensionLocally.ps1'
-        arguments: >
-          -CollectionUri $(System.CollectionUri)
-          -ProjectName 'Test Plan Extension'
-          -AccessToken $(System.AccessToken)
-          -TestResultFormat 'nunit'
-          -TestResultFiles '$(Build.SourcesDirectory)/examples/dotnet/NUnitExample/TestResults/TestResults.xml'
-          -TestPlan 'Primary Test Plan'
-          -TestConfigFilter ''
-          -TestConfigAliases ''
-          -TestCaseMatchStrategy ''
-          -TestCaseProperty 'TestCaseId'
-          -TestCaseRegex ''
-          -TestConfigProperty ''
-          -TestRunTitle '$(Build.DefinitionName) - $(nodeVersion)'
-          -BuildId $(Build.BuildId)
-          -ReleaseId ''
-          -ReleaseEnvironmentId ''
-          -DryRun ''
+    - ${{ each test in parameters.regressiontests }}:
+      - task: PowerShell@2
+        displayName: 'Run extension against ${{ test.name }}'
+        inputs:
+          workingDirectory: $(Pipeline.Workspace)/build
+          filePath: '$(Pipeline.Workspace)/build/Test-ExtensionLocally.ps1'
+          arguments: >
+            -CollectionUri $(System.CollectionUri)
+            -ProjectName 'Test Plan Extension'
+            -AccessToken $(System.AccessToken)
+            -TestResultFormat ${{ test.format }}
+            -TestResultFiles ${{ test.testResultsFile }}
+            -TestPlan 'Primary Test Plan'
+            -TestConfigFilter ''
+            -TestConfigAliases ''
+            -TestCaseMatchStrategy ''
+            -TestCaseProperty 'TestCaseId'
+            -TestCaseRegex ''
+            -TestConfigProperty ''
+            -TestRunTitle '$(Build.DefinitionName) - $(nodeVersion)'
+            -BuildId $(Build.BuildId)
+            -ReleaseId ''
+            -ReleaseEnvironmentId ''
+            -DryRun ''

--- a/devops/pipelines/marketplace-extension/pipeline.yml
+++ b/devops/pipelines/marketplace-extension/pipeline.yml
@@ -157,7 +157,6 @@ jobs:
         node20:
           AGENT_USE_NODE20: true
           nodeVersion: '20.x'
-      
           
     steps:
     - checkout: self
@@ -191,7 +190,7 @@ jobs:
             -TestConfigAliases ''
             -TestCaseMatchStrategy ''
             -TestCaseProperty 'TestCaseId'
-            -TestCaseRegex ''
+            -TestCaseRegex 'TestCase(\d+)'
             -TestConfigProperty ''
             -TestRunTitle '$(Build.DefinitionName) - $(nodeVersion)'
             -BuildId $(Build.BuildId)


### PR DESCRIPTION
This PR updates the testparser to [0.2.6](https://github.com/test-results-reporter/parser/releases/tag/v0.2.6) and integrates samples into integration tests