### PR TITLE
display enum named value in log output

### DIFF
--- a/PublishTestPlanResultsV1/processing/TestResultProcessor.ts
+++ b/PublishTestPlanResultsV1/processing/TestResultProcessor.ts
@@ -1,4 +1,4 @@
-import { TestPoint, TestPlan } from "azure-devops-node-api/interfaces/TestInterfaces";
+import { TestPoint, TestPlan, TestOutcome } from "azure-devops-node-api/interfaces/TestInterfaces";
 import { TestResultContext } from "../context/TestResultContext";
 import { TestFrameworkResult } from "../framework/TestFrameworkResult";
 import { TestResultMatch, TestResultMatchStrategy } from "./TestResultMatchStrategy";
@@ -73,7 +73,7 @@ export class TestResultProcessor {
       this.logger.info(`| Test Point | Automated Test | TestOutcome |`);
       this.logger.info('|------------|----------------|-------------|');
       result.matches.forEach( (value, key) => {
-        this.logger.info(`| ${key} | ${value.name} | ${value.outcome} |`);
+        this.logger.info(`| ${key} | ${value.name} | ${TestOutcome[value.outcome]} |`);
       });
     }
     if (result.unmatched.length > 0) {
@@ -94,7 +94,7 @@ export class TestResultProcessor {
     this.matchers.some( matcher => {
       
       let matchResult = matcher.isMatch( testResult, testPoint );
-      this.logger.debug(`Strategy: ${matcher.constructor.name} | TestPoint: ${testPoint.id} | MatchResult: ${matchResult.toString()} `);
+      this.logger.debug(`Strategy: ${matcher.constructor.name} | TestPoint: ${testPoint.id} | MatchResult: ${TestResultMatch[matchResult]} `);
 
       if (matchResult == TestResultMatch.Fail) {
         match = false;


### PR DESCRIPTION
This PR improves the output of the log output.

## Debug logging for match strategies

before (with `system.debug` enabled):

```
##vso[task.debug]Strategy: TestRegexMatchStrategy | TestPoint: 876 | MatchResult: 0
##vso[task.debug]Strategy: TestIdMatchStrategy | TestPoint: 876 | MatchResult: 2
##vso[task.debug]Strategy: TestConfigMatchStrategy | TestPoint: 877 | MatchResult: 0
##vso[task.debug]Strategy: TestNameMatchStrategy | TestPoint: 877 | MatchResult: 0
```

after:

```
##vso[task.debug]Strategy: TestRegexMatchStrategy | TestPoint: 876 | MatchResult: None
##vso[task.debug]Strategy: TestIdMatchStrategy | TestPoint: 876 | MatchResult: Fail
##vso[task.debug]Strategy: TestConfigMatchStrategy | TestPoint: 877 | MatchResult: None
##vso[task.debug]Strategy: TestNameMatchStrategy | TestPoint: 877 | MatchResult: None
```

## Summary report of matched tests

```
| Test Point | Automated Test | TestOutcome |
|------------|----------------|-------------|
| 879 | jUnit_passingTest_testCase4867 | 2 |
| 888 | jUnit_associateTestCaseUsingTestProperty | 2 |
| 881 | jUnit_skippedTest_testCase4869 | 8 |
| 884 | JUnit Match Test Case by Display Name | 2 |
| 880 | jUnit_failingTest_testCase4868 | 3 |
| 883 | jUnit_Match_TEST_case_By_Exact_Name_cAsE_iNsenSITive | 2 |
| 885 | jUnit_Match_Test_Case_By_Exact_Name | 2| 
```

after:

```
| Test Point | Automated Test | TestOutcome |
|------------|----------------|-------------|
| 879 | jUnit_passingTest_testCase4867 | Passed |
| 888 | jUnit_associateTestCaseUsingTestProperty | Passed |
| 881 | jUnit_skippedTest_testCase4869 | NotExecuted |
| 884 | JUnit Match Test Case by Display Name | Passed |
| 880 | jUnit_failingTest_testCase4868 | Passed |
| 883 | jUnit_Match_TEST_case_By_Exact_Name_cAsE_iNsenSITive | Passed |
| 885 | jUnit_Match_Test_Case_By_Exact_Name | Passed |
```
