### PR TITLE
improve debug logging for telemetry

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,13 @@ assignees: ''
 ---
 **Description**
 
-_provide a clear and concise description of what the bug is_
+_describe what you are attempting to do and the issue you are experiencing _
+
+_provide the `correlationId` that appears in the task log output:_
+
+```
+correlationId: ______
+```
 
 _provide sample usage of the task, if applicable_
 
@@ -35,6 +41,7 @@ paste your build output here
 ```
 
 **To Reproduce**
+
 Steps to reproduce the behaviour:
 1. Go to '...'
 2. Click on '....'

--- a/PublishTestPlanResultsV1/TaskParameters.ts
+++ b/PublishTestPlanResultsV1/TaskParameters.ts
@@ -139,13 +139,14 @@ class TaskParameters {
   /* Fetch the telemetry payload for this task execution */
   getTelemetryParameters(err?: any) : TelemetryPublisherParameters {
     const hasError = err !== undefined && err !== null;
-    const withErrorOrWithoutError = hasError ? "(error condition)" : "";
-    tl.debug(`reading TelemetryPublisherParameters from task inputs ${withErrorOrWithoutError}.`);
+    const withErrorOrWithoutError = hasError ? " (error condition)" : "";
+    tl.debug(`reading TelemetryPublisherParameters from task inputs${withErrorOrWithoutError}.`);
     // don't record stage so that we can publish which stage we last completed
 
     let dryRun = this.#getDryRun();
 
     const result = new TelemetryPublisherParameters();
+    result.errorPresent = hasError;
     result.displayTelemetryPayload = FeatureFlags.isFeatureEnabled(FeatureFlag.DisplayTelemetry); // TODO: deprecate
     result.displayTelemetryErrors = FeatureFlags.isFeatureEnabled(FeatureFlag.DisplayTelemetryErrors);
     result.publishTelemetry = FeatureFlags.isFeatureEnabled(FeatureFlag.PublishTelemetry) && !dryRun;

--- a/PublishTestPlanResultsV1/services/Logger.ts
+++ b/PublishTestPlanResultsV1/services/Logger.ts
@@ -13,6 +13,7 @@ export interface ILogger {
   info(message: string): void,
   warn(message: string): void,
   error(message: string): void
+  isDebugEnabled() : boolean;
 }
 
 export class Logger implements ILogger {
@@ -37,6 +38,10 @@ export class Logger implements ILogger {
 
   public error(message: string): void {
     this.log(LogLevel.Error, message);
+  }
+  
+  public isDebugEnabled() : boolean {
+    return this._level === LogLevel.Debug;
   }
 
   private log(level: LogLevel, message: string): void {
@@ -74,6 +79,9 @@ export class NullLogger implements ILogger {
   warn(message: string): void {
   }
   error(message: string): void {
+  }
+  isDebugEnabled() : boolean {
+    return false;
   }
 }
 

--- a/PublishTestPlanResultsV1/telemetry/TelemetryPublisher.ts
+++ b/PublishTestPlanResultsV1/telemetry/TelemetryPublisher.ts
@@ -39,7 +39,6 @@ export class TelemetryPublisher {
       // TODO: enable profiling for dependencies using a feature flag
       // TODO: add telemetry processor to mask customer server urls + ado organization/project details
       // TODO: instrument ado api calls with correlation ids as trackEvent does not do this automatically
-      // TODO: ensure that post-body or sensitive data is not sent in any dependency telemetry
       .setAutoCollectDependencies(false)
       .start();
     
@@ -69,10 +68,26 @@ export class TelemetryPublisher {
   }
 
   #displayTelemetry(parameters: TelemetryPublisherParameters) {
-    if (parameters.displayTelemetryPayload) {
+    // TODO: move to package.json?
+    const supportUrl = "https://github.com/bryanbcook/azdevops-testplan-extension/issues";
+    const debugEnabled = this.logger.isDebugEnabled();
+    const correlationId = parameters.payload['correlationId']! as string;
+    const payloadAsJson = parameters.displayTelemetryErrors ?
+      JSON.stringify(parameters.payload, null, 2) : 
+      JSON.stringify(parameters.payload);
+
+    if (debugEnabled && !parameters.displayTelemetryPayload) {
+      // include payload in debug logs
+      this.logger.debug("anonymous usage telemetry payload:");
+      this.logger.debug(payloadAsJson);
+    } else if (parameters.displayTelemetryPayload) {
       // dump telemetry payload to console for debugging
       this.logger.info("Telemetry Payload:");
-      this.logger.info(JSON.stringify(parameters.payload, null, 2));
+      this.logger.info(payloadAsJson);
+    }
+    this.logger.debug(`When reporting issues include correlation id: ${correlationId}`);
+    if (parameters.errorPresent) {
+      this.logger.info(`If you need assistance, please log an issue at ${supportUrl} referencing correlation id: ${correlationId}`);
     }
   }
 

--- a/PublishTestPlanResultsV1/telemetry/TelemetryPublisher.ts
+++ b/PublishTestPlanResultsV1/telemetry/TelemetryPublisher.ts
@@ -72,7 +72,7 @@ export class TelemetryPublisher {
     const supportUrl = "https://github.com/bryanbcook/azdevops-testplan-extension/issues";
     const debugEnabled = this.logger.isDebugEnabled();
     const correlationId = parameters.payload['correlationId']! as string;
-    const payloadAsJson = parameters.displayTelemetryErrors ?
+    const payloadAsJson = parameters.displayTelemetryPayload ?
       JSON.stringify(parameters.payload, null, 2) : 
       JSON.stringify(parameters.payload);
 

--- a/PublishTestPlanResultsV1/telemetry/TelemetryPublisherParameters.ts
+++ b/PublishTestPlanResultsV1/telemetry/TelemetryPublisherParameters.ts
@@ -1,6 +1,7 @@
 export class TelemetryPublisherParameters {
-  displayTelemetryPayload?: boolean;
-  displayTelemetryErrors?: boolean;
-  publishTelemetry?: boolean;
+  errorPresent: boolean = false;
+  displayTelemetryPayload: boolean = false;
+  displayTelemetryErrors: boolean = false;
+  publishTelemetry: boolean = false;
   payload: any;
 }


### PR DESCRIPTION
This PR includes the telemetry payload in the debug logs and includes the support url.