### PR TITLE
npm package updates

### DIFF
--- a/PublishTestPlanResultsV1/package-lock.json
+++ b/PublishTestPlanResultsV1/package-lock.json
@@ -16,11 +16,11 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
-        "@types/chai": "^5.2.3",
+        "@types/chai": "^4.3.20",
         "@types/mocha": "^10.0.3",
         "@types/node": "^20.19.37",
         "@types/q": "^1.5.7",
-        "@types/sinon": "^17.0.4",
+        "@types/sinon": "^21.0.0",
         "@types/uuid": "^8.3.2",
         "chai": "^4.5.0",
         "sinon": "^21.0.3",
@@ -415,15 +415,11 @@
       }
     },
     "node_modules/@types/chai": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/deep-eql": "*",
-        "assertion-error": "^2.0.1"
-      }
+      "license": "MIT"
     },
     "node_modules/@types/concat-stream": {
       "version": "1.6.1",
@@ -434,13 +430,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/deep-eql": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/form-data": {
       "version": "0.0.33",
@@ -490,9 +479,9 @@
       "license": "MIT"
     },
     "node_modules/@types/sinon": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
-      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
+      "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -603,16 +592,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/async-hook-jl": {
       "version": "1.7.6",

--- a/PublishTestPlanResultsV1/package.json
+++ b/PublishTestPlanResultsV1/package.json
@@ -18,11 +18,11 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/chai": "^5.2.3",
+    "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.3",
     "@types/node": "^20.19.37",
     "@types/q": "^1.5.7",
-    "@types/sinon": "^17.0.4",
+    "@types/sinon": "^21.0.0",
     "@types/uuid": "^8.3.2",
     "chai": "^4.5.0",
     "sinon": "^21.0.3",


### PR DESCRIPTION
Dependency updates for CVE's

- dev dependencies updated
- test-parser: 0.3.0 -> 0.4.0
- azure-devops-node-api: 12.5.0 -> 15.1.2

Vulnerability | CVSS2 | CVSS3 | CVSS4 | Dependency | Dependency Licenses
-- | -- | -- | -- | -- | --
CVE-2026-25896 | N/A | 9.3 | N/A | fast-xml-parser (npm) | MIT
CVE-2026-26996 | N/A | 7.5 | 8.7 | minimatch (npm) | BlueOak-1.0.0
CVE-2026-26996 | N/A | 7.5 | 8.7 | minimatch (npm) | BlueOak-1.0.0
CVE-2026-27601 | N/A | 7.5 | 8.2 | underscore (npm) | MIT
CVE-2026-27903 | N/A | 7.5 | N/A | minimatch (npm) | BlueOak-1.0.0
CVE-2026-27904 | N/A | 7.5 | N/A | minimatch (npm) | BlueOak-1.0.0
CVE-2026-27903 | N/A | 7.5 | N/A | minimatch (npm) | BlueOak-1.0.0
CVE-2026-27904 | N/A | 7.5 | N/A | minimatch (npm) | BlueOak-1.0.0
CVE-2026-26278 | N/A | 7.5 | N/A | fast-xml-parser (npm) | MIT
CVE-2025-15284 | N/A | 3.7 | 6.3 | qs (npm) | BSD-3-Clause
CVE-2026-2391 | N/A | 7.5 | 6.3 | qs (npm) | BSD-3-Clause
CVE-2026-27942 | N/A | 7.5 | 2.7 | fast-xml-parser (npm) | MIT
