### PR TITLE
remove publishtelemetry feature flag

### DIFF
--- a/PublishTestPlanResultsV1/TaskParameters.ts
+++ b/PublishTestPlanResultsV1/TaskParameters.ts
@@ -148,9 +148,9 @@ class TaskParameters {
 
     const result = new TelemetryPublisherParameters();
     result.errorPresent = hasError;
-    result.displayTelemetryPayload = FeatureFlags.isFeatureEnabled(FeatureFlag.DisplayTelemetry); // TODO: deprecate
-    result.displayTelemetryErrors = FeatureFlags.isFeatureEnabled(FeatureFlag.DisplayTelemetryErrors);
-    result.publishTelemetry = FeatureFlags.isFeatureEnabled(FeatureFlag.PublishTelemetry) && !dryRun;
+    result.displayTelemetryPayload = FeatureFlags.isFeatureEnabled(FeatureFlag.DisplayTelemetry); // allow enabling output for regression or local debugging
+    result.displayTelemetryErrors = FeatureFlags.isFeatureEnabled(FeatureFlag.DisplayTelemetryErrors); // allow users to show errors in telemetry publishing
+    result.publishTelemetry = !dryRun;
 
     result.payload = this.tph.getPayload(err, optOut);
     if (optOut) {

--- a/PublishTestPlanResultsV1/services/FeatureFlags.ts
+++ b/PublishTestPlanResultsV1/services/FeatureFlags.ts
@@ -3,7 +3,6 @@ import { getLogger, ILogger } from "./Logger";
 export class FeatureFlag {
   static DisplayTelemetry : string = "displaytelemetry";
   static DisplayTelemetryErrors : string = "displaytelemetryerrors";
-  static PublishTelemetry : string = "publishtelemetry";
 }
 
 export class FeatureFlags {

--- a/PublishTestPlanResultsV1/telemetry/TelemetryPublisherParameters.ts
+++ b/PublishTestPlanResultsV1/telemetry/TelemetryPublisherParameters.ts
@@ -2,6 +2,6 @@ export class TelemetryPublisherParameters {
   errorPresent: boolean = false;
   displayTelemetryPayload: boolean = false;
   displayTelemetryErrors: boolean = false;
-  publishTelemetry: boolean = false;
+  publishTelemetry: boolean = true;
   payload: any;
 }

--- a/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
+++ b/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
@@ -1466,35 +1466,19 @@ describe('TaskParameters', () => {
       });
     });
 
-    context(`FeatureFlag: ${FeatureFlag.PublishTelemetry}`, () =>  {
+    context('Publish telemetry', () =>  {
 
-      // TODO: deprecate
-      it(`should populate ${FeatureFlag.PublishTelemetry} from FeatureFlag`, () => {
+      it(`Should default to publishing telemetry`, () => {
         // arrange
-        util.setFeatureFlag(FeatureFlag.PublishTelemetry, "true");
         util.loadData();
-
         // act
         var parameters = subject.getTelemetryParameters();
-
         // assert
         expect(parameters.publishTelemetry).to.be.true;
       });
 
-      // TODO: deprecate
-      it(`should default ${FeatureFlag.PublishTelemetry} to false`, () => {
-        // arrange
-        util.loadData();
-        // act
-        var parameters = subject.getTelemetryParameters();
-        // assert
-        expect(parameters.publishTelemetry).to.be.false;
-      });
-
-      // TODO: remove from feature flag context
       it('Should recognize when dryRun is specified', () => {
         // arrange
-        util.setFeatureFlag(FeatureFlag.PublishTelemetry, "true");
         util.setInput("dryRun", "true");
         util.loadData();
 
@@ -1504,20 +1488,6 @@ describe('TaskParameters', () => {
         // assert
         expect(parameters.publishTelemetry).to.be.false;
       })
-
-      it('Should recognize when dryRun is not specified', () => {
-        // arrange
-        util.setFeatureFlag(FeatureFlag.PublishTelemetry, "true");
-        util.setInput("dryRun", "false");
-        util.loadData();
-
-        // act
-        var parameters = subject.getTelemetryParameters();
-
-        // assert
-        expect(parameters.publishTelemetry).to.be.true;
-      });
-
     });
 
     context(`FeatureFlag: ${FeatureFlag.DisplayTelemetry}`, () =>  {

--- a/PublishTestPlanResultsV1/test/TelemetryPublisher.specs.ts
+++ b/PublishTestPlanResultsV1/test/TelemetryPublisher.specs.ts
@@ -17,7 +17,6 @@ describe('TelemetryPublisher', () => {
     telemetryClientStub = sinon.createStubInstance<TelemetryClient>(TelemetryClient);
     subject = new TelemetryPublisher(loggerStub as ILogger, telemetryClientStub as TelemetryClient);
     parameters = new TelemetryPublisherParameters();
-    parameters.publishTelemetry = true; // TODO: remove with featureflag
   });
 
   it('should swallow any errors that occur when publishing telemetry', async () => {

--- a/devops/pipelines/marketplace-extension/regression-test.yml
+++ b/devops/pipelines/marketplace-extension/regression-test.yml
@@ -110,7 +110,7 @@ steps:
         -failTaskOnMissingResultsFile ''
         -failTaskOnMissingTests ''
         -failTaskOnUnmatchedTestCases ''
-        -featureFlags 'DisplayTelemetry,DisplayTelemetryErrors,PublishTelemetry'
+        -featureFlags 'DisplayTelemetry,DisplayTelemetryErrors'
         -DryRun ''
 
   - ${{ if ne(test.expectedResults, '') }}:


### PR DESCRIPTION
Resolves #116

This PR introduces anonymous telemetry publishing

Feature Flags related to telemetry:
- `PUBLISHTESTPLANRESULTS_DISPLAYTELEMETRY`: will show the entire JSON payload that is sent to telemetry endpoint. When not enabled, the telemetry is only shown when `$(System.Debug)` is set to `true`.
- `PUBLISHTESTPLANRESULTS_DISPLAYTELEMETRYERRORS`: will dump any errors that occur while publishing telemetry. When not enabled, error messages that occur are silently ignored.