### PR TITLE
fix: cross project publishing

### DIFF
--- a/PublishTestPlanResultsV1/TaskParameters.ts
+++ b/PublishTestPlanResultsV1/TaskParameters.ts
@@ -20,6 +20,7 @@ class TaskParameters {
   accessToken?: string;
   collectionUri?: string;
   projectName?: string;
+  originProjectName?: string;
 
   buildId?: string;
   releaseUri?: string;
@@ -109,15 +110,20 @@ class TaskParameters {
     const testFiles = this.testFiles.filter(file => file.indexOf('**') == -1);  
     let result = new TestRunPublisherParameters(
         this.collectionUri!, 
+        this.projectName!,
         this.accessToken!, 
         dryRun, 
         testRunTitle, 
-        this.buildId!,
+        this.buildId,
         testFiles,
         failTaskOnUnmatchedTestCases
         );
     result.releaseUri = this.releaseUri;
     result.releaseEnvironmentUri = this.releaseEnvironmentUri;
+
+    if (this.projectName != this.originProjectName) {
+      result.buildId = undefined;
+    }
 
     this.tph.recordStage("publishTestRunResults");
     return result;
@@ -164,8 +170,9 @@ class TaskParameters {
 
   #ensureCredentialsAreSet() {
     if (!this.accessToken) {
+      this.originProjectName = tl.getVariable("SYSTEM_TEAMPROJECT");
       this.accessToken = this.tph.getInputOrFallback("accessToken", () => tl.getVariable("SYSTEM_ACCESSTOKEN"), { recordNonDefault: true });
-      this.projectName = this.tph.getInputOrFallback("projectName", () => tl.getVariable("SYSTEM_TEAMPROJECT"), { recordNonDefault: true, anonymize: true }, PrivacyLevel.Normal);
+      this.projectName = this.tph.getInputOrFallback("projectName", () => this.originProjectName, { recordNonDefault: true, anonymize: true }, PrivacyLevel.Normal);
       this.collectionUri = this.tph.getInputOrFallback("collectionUri", () => tl.getVariable("SYSTEM_COLLECTIONURI"), { recordNonDefault: true, anonymize: true }, PrivacyLevel.Minimum);
 
       let serverType = (this.collectionUri && (this.collectionUri.startsWith("https://dev.azure.com/") || this.collectionUri.includes(".visualstudio.com"))) ?

--- a/PublishTestPlanResultsV1/TaskParameters.ts
+++ b/PublishTestPlanResultsV1/TaskParameters.ts
@@ -121,8 +121,11 @@ class TaskParameters {
     result.releaseUri = this.releaseUri;
     result.releaseEnvironmentUri = this.releaseEnvironmentUri;
 
+    // detect if we are publishing to a test plan in a different project
     if (this.projectName != this.originProjectName) {
       result.buildId = undefined;
+      result.releaseUri = undefined;
+      result.releaseEnvironmentUri = undefined;
     }
 
     this.tph.recordStage("publishTestRunResults");

--- a/PublishTestPlanResultsV1/publishing/TestRunPublisher.ts
+++ b/PublishTestPlanResultsV1/publishing/TestRunPublisher.ts
@@ -26,7 +26,7 @@ export class TestRunPublisher {
 
   private ado : AdoWrapper;
   private logger : ILogger;
-  public buildId : string;
+  public buildId : string | undefined;
   public dryRun : boolean;
   public releaseUri? : string;
   public releaseEnvironmentUri? : string;

--- a/PublishTestPlanResultsV1/publishing/TestRunPublisherParameters.ts
+++ b/PublishTestPlanResultsV1/publishing/TestRunPublisherParameters.ts
@@ -1,16 +1,18 @@
 export class TestRunPublisherParameters {
   public accessToken: string;
-  public buildId : string;
+  public buildId : string | undefined;
   public collectionUri: string;
   public dryRun : boolean;
+  public projectName: string;
   public releaseUri?: string;
   public releaseEnvironmentUri?: string;
   public testRunTitle : string;
   public testFiles : string[];
   public failTaskOnUnmatchedTestCases : boolean;
 
-  constructor(collectionUri: string, accessToken: string, dryRun: boolean, testRunTitle : string, buildId : string, testFiles : string[], failTaskOnUnmatchedTestCases : boolean) {
+  constructor(collectionUri: string, projectName: string, accessToken: string, dryRun: boolean, testRunTitle : string, buildId : string | undefined, testFiles : string[], failTaskOnUnmatchedTestCases : boolean) {
       this.collectionUri = collectionUri;
+      this.projectName = projectName;
       this.accessToken = accessToken;
       this.buildId = buildId;
       this.dryRun = dryRun;

--- a/PublishTestPlanResultsV1/services/AdoWrapper.ts
+++ b/PublishTestPlanResultsV1/services/AdoWrapper.ts
@@ -133,7 +133,7 @@ export class AdoWrapper {
    * @param releaseEnvironmentUri url to the release environment
    * @returns returns the resulting TestRun from the operation
    */
-  async createTestRun(projectId : string, testPlanId : number, testPoints : number[], buildId : string, releaseUri? : string, releaseEnvironmentUri? : string) : Promise<Contracts.TestRun> {
+  async createTestRun(projectId : string, testPlanId : number, testPoints : number[], buildId? : string, releaseUri? : string, releaseEnvironmentUri? : string) : Promise<Contracts.TestRun> {
     this.logger.debug(`createTestRun projectId:${projectId} testPlanId:${testPlanId} testPoints: (${testPoints.length} items) - buildId:${buildId}`);
 
     let testRun : Contracts.RunCreateModel = {
@@ -142,9 +142,6 @@ export class AdoWrapper {
       plan: <Contracts.ShallowReference>{
         id: testPlanId.toString()
       },
-      build: <Contracts.ShallowReference>{
-        id: buildId,
-      },
       releaseUri: releaseUri,
       releaseEnvironmentUri: releaseEnvironmentUri,
       pointIds: testPoints,
@@ -152,9 +149,12 @@ export class AdoWrapper {
       configurationIds: []
     };
 
-    // temp: disable build id association when test plan is different project than pipeline
-    if (FeatureFlags.isFeatureEnabled(FeatureFlag.DisableBuildAssociation)) {
-      testRun.build = undefined;
+    if (buildId !== undefined) {
+      testRun.build = <Contracts.ShallowReference>{
+        id: buildId
+      }
+    } else {
+      this.logger.debug('Build association is not supported when the test project is different from the pipeline project.');
     }
 
     return await this.testApi.createTestRun(testRun, projectId);

--- a/PublishTestPlanResultsV1/services/AdoWrapper.ts
+++ b/PublishTestPlanResultsV1/services/AdoWrapper.ts
@@ -7,7 +7,6 @@ import { ITestApi } from "azure-devops-node-api/TestApi";
 import * as fs from "fs";
 import path from "path";
 import { ILogger, getLogger } from "./Logger";
-import FeatureFlags, { FeatureFlag } from "./FeatureFlags";
 
 interface AdoResponseHeaders {
   "x-ms-continuationtoken"? : string;

--- a/PublishTestPlanResultsV1/services/FeatureFlags.ts
+++ b/PublishTestPlanResultsV1/services/FeatureFlags.ts
@@ -3,7 +3,6 @@ import { getLogger, ILogger } from "./Logger";
 export class FeatureFlag {
   static DisplayTelemetry : string = "displaytelemetry";
   static DisplayTelemetryErrors : string = "displaytelemetryerrors";
-  static DisableBuildAssociation : string = "disablebuildassociation";
 }
 
 export class FeatureFlags {

--- a/PublishTestPlanResultsV1/test/AdoWrapper.specs.ts
+++ b/PublishTestPlanResultsV1/test/AdoWrapper.specs.ts
@@ -162,21 +162,23 @@ describe("AdoWrapper", () => {
 
   context("Create Test Run", () => {
 
-    it(`Should disable build association when ${FeatureFlag.DisableBuildAssociation} feature flag is enabled`, async () => {
+    // unit test / stub out testApi
+    // cross-project publishing scenarios require build association to be disabled, so buildId is optional in createTestRun parameters and test
+    it(`Should disable build association when buildId is not provided`, async () => {
       // arrange
       const createTestRunStub = stubCreateTestRun(<Contracts.TestRun>{ id: 123 });
-      testUtil.setFeatureFlag(FeatureFlag.DisableBuildAssociation, "true");
-      testUtil.loadData();
 
       // act
-      await subject.createTestRun(projectId, parseInt(planId), [1,2,3], "buildId");
+      await subject.createTestRun(projectId, parseInt(planId), [1,2,3], undefined);
 
       // assert
       let testRun = createTestRunStub.getCall(0).args[1] as Contracts.TestRun;
       expect(testRun.build).to.be.undefined;
     });
 
-    it(`Should include build association when ${FeatureFlag.DisableBuildAssociation} feature flag is not provided`, async () => {
+    // unit test / stub out testApi
+    // build association is associated with 
+    it(`Should include build association when buildId is provided`, async () => {
       // arrange
       const createTestRunStub = stubCreateTestRun(<Contracts.TestRun>{ id: 123 });
       testUtil.loadData();

--- a/PublishTestPlanResultsV1/test/AdoWrapper.specs.ts
+++ b/PublishTestPlanResultsV1/test/AdoWrapper.specs.ts
@@ -177,6 +177,21 @@ describe("AdoWrapper", () => {
     });
 
     // unit test / stub out testApi
+    // cross-project publishing scenarios require release association to be disabled, so releaseUri and releaseEnvironmentUri are optional in createTestRun parameters and test
+    it(`Should disable release association when releaseUri and releaseEnvironmentUri are not provided`, async () => {
+      // arrange
+      const createTestRunStub = stubCreateTestRun(<Contracts.TestRun>{ id: 123 });
+
+      // act
+      await subject.createTestRun(projectId, parseInt(planId), [1,2,3], undefined, undefined, undefined);
+
+      // assert
+      let testRun = createTestRunStub.getCall(0).args[1] as Contracts.TestRun;
+      expect(testRun.releaseUri).to.be.undefined;
+      expect(testRun.releaseEnvironmentUri).to.be.undefined;
+    });
+
+    // unit test / stub out testApi
     // build association is associated with 
     it(`Should include build association when buildId is provided`, async () => {
       // arrange

--- a/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
+++ b/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
@@ -1095,17 +1095,6 @@ describe('TaskParameters', () => {
         expect(parameters.accessToken).to.eq("myToken");
       });
 
-      it("Should default failTaskOnUnmatchedTestCases to true", () => {
-        // arrange
-        util.loadData();
-
-        // act
-        var parameters = subject.getPublisherParameters();
-
-        // assert
-        expect(parameters.failTaskOnUnmatchedTestCases).to.be.true;
-      });
-
       it('Should record failTaskOnUnmatchedTestCases in telemetry when custom value is provided', () => {
         // arrange
         util.setInput("failTaskOnUnmatchedTestCases", "false");
@@ -1168,10 +1157,9 @@ describe('TaskParameters', () => {
 
         // assert
         let telemetry = subject.getTelemetryParameters().payload;
-        expect(telemetry.testRunTitle).to.be.undefined;
+        expect(telemetry.testRunTitle).to.be.undefined; // don't record user value
         expect(telemetry.testRunTitle_custom).to.be.true;
       });
-
     });
 
     context('default values', () => {
@@ -1216,61 +1204,6 @@ describe('TaskParameters', () => {
       })
     });
 
-    context('user supplied values', () => {
-
-      it('Should resolve testRunTitle if provided', () => {
-        // arrange
-        util.setInput("testRunTitle", "My Test Run");
-        util.loadData();
-
-        // act
-        var parameters = subject.getPublisherParameters();
-
-        // assert
-        expect(parameters.testRunTitle).to.eq("My Test Run");
-      });
-
-      it('Should record custom value for testRunTitle in telemetry when provided', () => {
-        // arrange
-        util.setInput("testRunTitle", "My Test Run");
-        util.loadData();
-
-        // act
-        subject.getPublisherParameters();
-
-        // assert
-        let telemetry = subject.getTelemetryParameters().payload;
-        expect(telemetry.testRunTitle).to.be.undefined; // don't record user value
-        expect(telemetry.testRunTitle_custom).to.be.true;
-      });
-
-      it('Should resolve value for failTaskOnUnmatchedTestCases from input', () => {
-        // arrange
-        util.setInput("failTaskOnUnmatchedTestCases", "false"); // default is true
-        util.loadData();
-
-        // act
-        var parameters = subject.getPublisherParameters();
-
-        // assert
-        expect(parameters.failTaskOnUnmatchedTestCases).to.be.false;
-      });
-
-      it('Should record custom value for failTaskOnUnmatchedTestCases in telemetry when provided', () => {
-        // arrange
-        util.setInput("failTaskOnUnmatchedTestCases", "false");
-        util.loadData();
-
-        // act
-        subject.getPublisherParameters();
-
-        // assert
-        let telemetry = subject.getTelemetryParameters().payload;
-        expect(telemetry.failTaskOnUnmatchedTestCases).to.be.false;
-        expect(telemetry.failTaskOnUnmatchedTestCases_custom).to.be.undefined;
-      });
-    });
-
     context('For Build Pipeline', () => {
 
       it('Should resolve build id from build pipeline', () => {
@@ -1301,7 +1234,6 @@ describe('TaskParameters', () => {
         expect(parameters.releaseUri).to.be.undefined;
         expect(parameters.releaseEnvironmentUri).to.be.undefined;
       });
-
     });  
 
     context("For Release Pipeline", () => {
@@ -1319,6 +1251,43 @@ describe('TaskParameters', () => {
         // assert
         expect(parameters.releaseUri).to.satisfy( (x: string) => x.startsWith("vstfs://ReleaseManagement"));
         expect(parameters.releaseEnvironmentUri).to.satisfy( (x: string) => x.startsWith("vstfs://ReleaseManagement"));
+      });
+    });
+
+    context('Cross project publishing', () => {
+    
+      it('Should exclude buildId when publishing to Test Plans in a different project', () => {
+        // arrange
+        util.setInput("collectionUri", "https://myorg.visualstudio.com/");
+        util.setInput("projectName", "MyProject");
+        util.setInput("testPlan", "My Test Plan");
+        util.setSystemVariable("BUILD_BUILDID", "1234");
+        util.setSystemVariable("SYSTEM_TEAMPROJECT", "OriginProject");
+        util.loadData();
+
+        // act 
+        subject = TaskParameters.getInstance(); // reload to pick up values from constructor
+        var parameters = subject.getPublisherParameters();
+
+        // assert
+        expect(parameters.buildId).to.be.undefined;
+      });
+
+      it('Should include buildId when publishing to Test Plans in the same project', () => {
+        // arrange
+        util.setInput("collectionUri", "https://myorg.visualstudio.com/");
+        util.setInput("projectName", "MyProject");
+        util.setInput("testPlan", "My Test Plan");
+        util.setSystemVariable("BUILD_BUILDID", "1234");
+        util.setSystemVariable("SYSTEM_TEAMPROJECT", "MyProject");
+        util.loadData();
+
+        // act
+        subject = TaskParameters.getInstance(); // reload to pick up values from constructor
+        var parameters = subject.getPublisherParameters();
+
+        // assert
+        expect(parameters.buildId).to.eq("1234");
       });
     });
     

--- a/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
+++ b/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
@@ -1256,13 +1256,15 @@ describe('TaskParameters', () => {
 
     context('Cross project publishing', () => {
     
-      it('Should exclude buildId when publishing to Test Plans in a different project', () => {
+      it('Should exclude build and release associations when publishing to Test Plans in a different project', () => {
         // arrange
         util.setInput("collectionUri", "https://myorg.visualstudio.com/");
         util.setInput("projectName", "MyProject");
         util.setInput("testPlan", "My Test Plan");
         util.setSystemVariable("BUILD_BUILDID", "1234");
         util.setSystemVariable("SYSTEM_TEAMPROJECT", "OriginProject");
+        util.setSystemVariable("RELEASE_RELEASEURI", "vstfs://ReleaseManagement/Release/1234");
+        util.setSystemVariable("RELEASE_ENVIRONMENTURI", "vstfs://ReleaseManagement/Environment/5678");
         util.loadData();
 
         // act 
@@ -1271,6 +1273,8 @@ describe('TaskParameters', () => {
 
         // assert
         expect(parameters.buildId).to.be.undefined;
+        expect(parameters.releaseUri).to.be.undefined;
+        expect(parameters.releaseEnvironmentUri).to.be.undefined;
       });
 
       it('Should include buildId when publishing to Test Plans in the same project', () => {

--- a/PublishTestPlanResultsV1/test/TestRunPublisher.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestRunPublisher.specs.ts
@@ -63,13 +63,14 @@ context("TestRunPublisher", () => {
       // this resolves endpoint information from the server, so values must be present
       this.timeout(10000);
       const serverUrl = process.env.SYSTEM_COLLECTIONURI as string;
+      const projectName = process.env.SYSTEM_TEAMPROJECT as string;
       const accessToken = (process.env.SYSTEM_ACCESSTOKEN ?? process.env.ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN) as string;
       const buildId = "123";
       const rUri = "vstfs://ReleaseManagement/Release/1";
       const eUri = "vstfs://ReleaseManagement/Environment/1";
       const testFiles = ["file1", "file2"];
       console.log(serverUrl);
-      var parameters = new TestRunPublisherParameters(serverUrl, accessToken, false, "Dummy", buildId, testFiles, true);
+      var parameters = new TestRunPublisherParameters(serverUrl, projectName, accessToken, false, "Dummy", buildId, testFiles, true);
       parameters.releaseUri = rUri;
       parameters.releaseEnvironmentUri = eUri;
 
@@ -190,6 +191,21 @@ context("TestRunPublisher", () => {
         })
       )).eq(true);
     })
+
+    context("With Build Information available", () => {
+
+      it("Should include build information in the test run", async () => {
+        // arrange
+        let buildId = "123";
+        subject.buildId = buildId;
+        
+        // act
+        var result = await subject.publishTestRun(testData);
+
+        // assert
+        expect(ado.createTestRun.calledWith( "project1", 1, [1,2], buildId)).eq(true);
+      });
+    });
 
     context("With Classic Release Information available", () => {
 

--- a/devops/pipelines/marketplace-extension/regression-test.yml
+++ b/devops/pipelines/marketplace-extension/regression-test.yml
@@ -103,8 +103,8 @@ steps:
         -TestConfigProperty ''
         -TestRunTitle '$(Build.DefinitionName) - $(nodeVersion) - ${{ test.name }}'
         -BuildId $(Build.BuildId)
-        -ReleaseId '${{ if ne(test.releaseId,''), test.releaseId, '' }}'
-        -ReleaseEnvironmentId '${{ if ne(test.releaseEnvironmentId,''), test.releaseEnvironmentId, '' }}'
+        -ReleaseId '${{ iif( ne(test.releaseId,''), test.releaseId, '' ) }}'
+        -ReleaseEnvironmentId '${{ iif( ne(test.releaseEnvironmentId,''), test.releaseEnvironmentId, '' ) }}'
         -failTaskOnFailedTests '${{ iif( ne(test.failTaskOnFailedTests,''), test.failTaskOnFailedTests, 'false' ) }}'
         -failTaskOnSkippedTests '${{ iif( ne(test.failTaskOnSkippedTests,''), test.failTaskOnSkippedTests, 'false' ) }}'
         -failTaskOnMissingResultsFile ''

--- a/devops/pipelines/marketplace-extension/regression-test.yml
+++ b/devops/pipelines/marketplace-extension/regression-test.yml
@@ -40,6 +40,8 @@ parameters:
     testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/xUnitResults/TestResults-adotestplan-prj.xml'
     projectName: 'ADO Test Automation'
     testplan: 'Plan w Duplicates'
+    releaseId: vstfs:///ReleaseManagement/Release/8
+    releaseEnvironmentId: vstfs:///ReleaseManagement/Environment/8
     expectedResults:
       - outcome: Passed
         count: 1
@@ -101,8 +103,8 @@ steps:
         -TestConfigProperty ''
         -TestRunTitle '$(Build.DefinitionName) - $(nodeVersion) - ${{ test.name }}'
         -BuildId $(Build.BuildId)
-        -ReleaseId ''
-        -ReleaseEnvironmentId ''
+        -ReleaseId '${{ if ne(test.releaseId,''), test.releaseId, '' }}'
+        -ReleaseEnvironmentId '${{ if ne(test.releaseEnvironmentId,''), test.releaseEnvironmentId, '' }}'
         -failTaskOnFailedTests '${{ iif( ne(test.failTaskOnFailedTests,''), test.failTaskOnFailedTests, 'false' ) }}'
         -failTaskOnSkippedTests '${{ iif( ne(test.failTaskOnSkippedTests,''), test.failTaskOnSkippedTests, 'false' ) }}'
         -failTaskOnMissingResultsFile ''

--- a/devops/pipelines/marketplace-extension/regression-test.yml
+++ b/devops/pipelines/marketplace-extension/regression-test.yml
@@ -43,13 +43,11 @@ parameters:
     expectedResults:
       - outcome: Passed
         count: 1
-    featureFlags: 'DisableBuildAssociation'
   - name: TestDuplicates_wTestOutcomeSettingEnabled
     format: xunit
     testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/xUnitResults/TestResults-adotestplan-prj.xml'
     projectName: 'ADO Test Automation'
     testplan: 'Plan w Duplicates and TestOutcome Setting Enabled'
-    buildId: 2436 # TODO: remove when 137 is fixed
     expectedResults:
       - outcome: Passed
         count: 2        
@@ -102,7 +100,7 @@ steps:
         -TestCaseRegex 'TestCase(\d+)'
         -TestConfigProperty ''
         -TestRunTitle '$(Build.DefinitionName) - $(nodeVersion) - ${{ test.name }}'
-        -BuildId ${{ iif( ne(test.buildId,''), test.buildId, '$(Build.BuildId)' ) }}
+        -BuildId $(Build.BuildId)
         -ReleaseId ''
         -ReleaseEnvironmentId ''
         -failTaskOnFailedTests '${{ iif( ne(test.failTaskOnFailedTests,''), test.failTaskOnFailedTests, 'false' ) }}'


### PR DESCRIPTION
Resolves #137 

This fix disables build and release association when publishing test results to a test plan in a different project.

Temporary Feature flag `PUBLISHTESTPLANRESULTS_DISABLEBUILDASSOCIATION` has been removed.