### PR TITLE
Update marketplace pipelines

### DIFF
--- a/devops/pipelines/marketplace-extension/pipeline.yml
+++ b/devops/pipelines/marketplace-extension/pipeline.yml
@@ -91,6 +91,8 @@ jobs:
       version: 'v0.x'
       checkLatest: true
 
+  - template: ../steps/obtain-marketplace-accesstoken.yml
+
   # fetch the current extension version
   #   You must build and upload manually for the first execution
   #   specify the Extension.VersionOverride variable at queue time to override this value
@@ -99,7 +101,7 @@ jobs:
     name: Query
     inputs:
       connectTo: 'VsTeam'
-      connectedServiceName: 'AzureDevOpsMarketplace'
+      connectedServiceName: '$(MarketplaceServiceConnection)'
       publisherId: '$(PublisherID)'
       extensionId: '$(ExtensionID)'
       versionAction: 'Patch'
@@ -125,7 +127,7 @@ jobs:
     condition: eq('${{ parameters.publishExtension}}', 'true')
     inputs:
       connectTo: 'VsTeam'
-      connectedServiceName: 'AzureDevOpsMarketplace' 
+      connectedServiceName: '$(MarketplaceServiceConnection)' 
       fileType: 'vsix'
       vsixFile: '$(Build.ArtifactStagingDirectory)/*.vsix'
       publisherId: '$(PublisherID)'

--- a/devops/pipelines/marketplace-extension/pipeline.yml
+++ b/devops/pipelines/marketplace-extension/pipeline.yml
@@ -91,7 +91,7 @@ jobs:
       version: 'v0.x'
       checkLatest: true
 
-  - template: ../steps/obtain-marketplace-accesstoken.yml
+  - template: /devops/steps/obtain-marketplace-accesstoken.yml
 
   # fetch the current extension version
   #   You must build and upload manually for the first execution

--- a/devops/pipelines/marketplace-extension/temp.yml
+++ b/devops/pipelines/marketplace-extension/temp.yml
@@ -1,0 +1,9 @@
+steps:
+- task: AzureCLI@2
+  displayName: 'Fetch profile for Service Principal'
+  inputs:
+    azureSubscription: 'azure-devops-marketplace'
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
+      az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798

--- a/devops/pipelines/marketplace-extension/temp.yml
+++ b/devops/pipelines/marketplace-extension/temp.yml
@@ -1,9 +1,0 @@
-steps:
-- task: AzureCLI@2
-  displayName: 'Fetch profile for Service Principal'
-  inputs:
-    azureSubscription: 'azure-devops-marketplace'
-    scriptType: pscore
-    scriptLocation: inlineScript
-    inlineScript: |
-      az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me --resource 499b84ac-1321-427f-aa17-267ca6975798

--- a/devops/pipelines/share-marketplace-extension/pipeline.yaml
+++ b/devops/pipelines/share-marketplace-extension/pipeline.yaml
@@ -24,13 +24,15 @@ steps:
     version: 'v0.x'
     checkLatest: true
 
+- template: /devops/steps/obtain-marketplace-accesstoken.yml
+
 # share the extension
 # --share-with only adds new organizations, existing orgs are untouched
 - task: ShareAzureDevOpsExtension@5
   displayName: 'Share Extension with Organization'
   inputs:
     connectTo: 'VsTeam'
-    connectedServiceName: 'AzureDevOpsMarketplace'
+    connectedServiceName: '$(MarketplaceServiceConnection)'
     method: 'id'
     publisherId: '$(PublisherID)'
     extensionId: '$(ExtensionID)'

--- a/devops/steps/obtain-marketplace-accesstoken.yml
+++ b/devops/steps/obtain-marketplace-accesstoken.yml
@@ -1,0 +1,16 @@
+# uses $(MarketplaceServiceConnection) stored in pipeline-extension-settings variable group. This is the ID of the service connection
+
+
+steps:
+- task: AzureCLI@2
+  displayName: 'Obtain Access Token for Marketplace API'
+  inputs:
+    azureSubscription: 'azure-devops-marketplace'
+    scriptType: 'pscore'
+    scriptLocation: 'inlineScript'
+    useGlobalConfig: true
+    inlineScript: |
+      $accessToken = az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query "accessToken" --output tsv
+      write-host "##vso[task.setsecret]$accessToken"
+      write-host "##vso[task.setendpoint id=$env:MARKETPLACESERVICECONNECTION;field=authParameter;key=password]$accessToken"
+          


### PR DESCRIPTION
This PR modifies pipelines to use this [guidance to upgrade to OIDC-backed access tokens]( https://jessehouwing.net/publish-azure-devops-extensions-using-workload-identity-oidc/) as Microsoft is [discontinuing global PAT tokens](https://devblogs.microsoft.com/devops/retirement-of-global-personal-access-tokens-in-azure-devops/).