### PR TITLE
Record TestCase start/end timestamps

### DIFF
--- a/PublishTestPlanResultsV1/framework/TestFrameworkResult.ts
+++ b/PublishTestPlanResultsV1/framework/TestFrameworkResult.ts
@@ -10,6 +10,8 @@ const TestParserMapping = {
 export class TestFrameworkResult {
   name: string;
   duration: number | undefined;
+  startedDate: Date | undefined;
+  completedDate: Date | undefined;
   stacktrace: string | undefined;
   failure: string | undefined;
   outcome: TestOutcome = TestOutcome.None;

--- a/PublishTestPlanResultsV1/framework/TestFrameworkResultReader.ts
+++ b/PublishTestPlanResultsV1/framework/TestFrameworkResultReader.ts
@@ -68,6 +68,8 @@ export class TestFrameworkResultReader {
         result.failure = test.failure;
         result.stacktrace = test.stack_trace;
         result.duration = test.duration;
+        result.startedDate = test.startTime;
+        result.completedDate = test.endTime;
         // 0.1.19 separated tags from metadata
         result.properties = new Map<string,string>(Object.entries(test.metadata));
 

--- a/PublishTestPlanResultsV1/publishing/TestRunPublisher.ts
+++ b/PublishTestPlanResultsV1/publishing/TestRunPublisher.ts
@@ -75,10 +75,12 @@ export class TestRunPublisher {
           let frameworkResult = results.matches.get(parseInt(pointId)) as TestFrameworkResult;
           r.outcome = frameworkResult.outcome.toString(); // sends integer value to API which is supported
           r.durationInMs = frameworkResult.duration;
+          r.startedDate = frameworkResult.startedDate;
+          r.completedDate = frameworkResult.completedDate;
           r.errorMessage = frameworkResult.failure;
           r.stackTrace = frameworkResult.stacktrace;
           r.state = "Completed";
-
+          
           if (frameworkResult.hasAttachments()) {
             testAttachments.set(r.id!, frameworkResult.attachments);
           }

--- a/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestFrameworkResultReader.specs.ts
@@ -69,16 +69,18 @@ describe("TestFramework Results Reader", () => {
     expect(results[0].properties.get("TestProduct")).to.equal('TestProductExample');
   });
 
-  // https://github.com/bryanbcook/azdevops-testplan-extension/issues/98
-  it("Can detect when wildcard files do not resolve to any files", async () => {
+  // https://github.com/bryanbcook/azdevops-testplan-extension/issues/122
+  it("Can read xUnit start and end times", async () => {
     // arrange
-    files.push(path.join(baseDir, "**", "non-existing-file.xml"));
+    files.push(path.join(baseDir, "xunit/xunit3.xml")); // uses xml3 format which has start and end times
+    
+    // act
+    var results = await subject.read("xunit", files);
 
-    // act / assert
-    await util.shouldThrowAsync( async () => { await subject.read("xunit", files); }, 
-      /No test results found for format 'xunit' in files: .*[\\/]\*\*[\\/]+non-existing-file\.xml/
-    );
-  })
+    // assert
+    expect(results[0].startedDate).to.be.instanceOf(Date);
+    expect(results[0].completedDate).to.be.instanceOf(Date);
+  });
 
   // https://github.com/bryanbcook/azdevops-testplan-extension/issues/48
   it("Can read xUnit time", async () => {
@@ -90,8 +92,18 @@ describe("TestFramework Results Reader", () => {
 
     // assert
     expect(results[0].duration).to.eq(86006.5);
-  });
- 
+  });  
+
+  // https://github.com/bryanbcook/azdevops-testplan-extension/issues/98
+  it("Can detect when wildcard files do not resolve to any files", async () => {
+    // arrange
+    files.push(path.join(baseDir, "**", "non-existing-file.xml"));
+
+    // act / assert
+    await util.shouldThrowAsync( async () => { await subject.read("xunit", files); }, 
+      /No test results found for format 'xunit' in files: .*[\\/]\*\*[\\/]+non-existing-file\.xml/
+    );
+  }) 
  
   it("Can read jUnit results", async () => {
     // arrange
@@ -260,6 +272,19 @@ describe("TestFramework Results Reader", () => {
     expect(results.length).to.eq(2);
     expect(results[0].attachments.length).to.be.greaterThan(0);
   })
+
+  // https://github.com/bryanbcook/azdevops-testplan-extension/issues/122
+  it("Can read MStest start and end times", async () => {
+    // arrange
+    files.push(path.join(baseDir, "mstest", "testresults.trx")); // uses xml3 format which has start and end times
+    
+    // act
+    var results = await subject.read("mstest", files);
+
+    // assert
+    expect(results[0].startedDate).to.be.instanceOf(Date);
+    expect(results[0].completedDate).to.be.instanceOf(Date);
+  });  
 
   async function fixLocalPaths(file: string) {
     let repositoryRoot = path.join(__dirname, "..", "..");

--- a/PublishTestPlanResultsV1/test/TestRunPublisher.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestRunPublisher.specs.ts
@@ -132,32 +132,61 @@ context("TestRunPublisher", () => {
       var result = await subject.publishTestRun(testData);
 
       // assert
-      expect(ado.updateTestResults.calledWith(
+      expect(ado.updateTestResults.calledWithMatch(
         "project1",
         400,
         [
-          <Contracts.TestCaseResult>{
+          sinon.match({
             id: 100001,
-            testPoint: <any>{
-              id: "1"
-            },
-            outcome: "2" /* VERIFY */,
+            testPoint: sinon.match({ id: "1" }),
+            outcome: "2",
             state: "Completed",
             stackTrace: undefined,
             errorMessage: undefined,
             durationInMs: 1000,
-          },
-          <Contracts.TestCaseResult>{
+          }),
+          sinon.match({
             id: 100002,
-            testPoint: <any>{
-              id: "2"
-            },
-            outcome: "2" /* VERIFY */,
+            testPoint: sinon.match({ id: "2" }),
+            outcome: "2",
             state: "Completed",
             stackTrace: undefined,
             errorMessage: undefined,
             durationInMs: 1000,
-          },
+          }),
+        ]
+      )).eq(true);
+    });
+
+    it("Should record start and end times for test results", async () => {
+      // arrange
+      testData.matches.clear();
+
+      let started1 = new Date(2024, 0, 1, 12, 0, 0);
+      let completed1 = new Date(2024, 0, 1, 12, 0, 1);
+      testData.matches.set(/*testpoint*/ 1, testUtil.newTestFrameworkResult("Test1", "PASS", undefined, started1, completed1));
+      let started2 = new Date(2024, 0, 1, 12, 0, 2);
+      let completed2 = new Date(2024, 0, 1, 12, 0, 3);
+      testData.matches.set(/*testpoint*/ 2, testUtil.newTestFrameworkResult("Test2", "PASS", undefined, started2, completed2));
+
+      // act
+      var result = await subject.publishTestRun(testData);
+
+            // assert
+      expect(ado.updateTestResults.calledWithMatch(
+        "project1",
+        400,
+        [
+          sinon.match({
+            id: 100001,
+            startedDate: started1,
+            completedDate: completed1
+          }),
+          sinon.match({
+            id: 100002,
+            startedDate: started2,
+            completedDate: completed2
+          }),
         ]
       )).eq(true);
     });

--- a/PublishTestPlanResultsV1/test/data/xunit/xunit3.xml
+++ b/PublishTestPlanResultsV1/test/data/xunit/xunit3.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assemblies schema-version="3" id="cafcb873-f15d-4881-8085-2a1e622abc9c" computer="REDACTED" user="bryan.b.cook" start-rtf="2025-11-28T19:10:25.8223596-05:00" finish-rtf="2025-11-29T00:10:25.9039940+00:00" timestamp="11/28/2025 19:10:25">
+    <assembly environment="64-bit (x64) .NET 9.0.5 [collection-per-class, parallel (8 threads)]" id="850e8924-5338-4158-868f-6a982d0892b3" name="C:\dev\code\_Experiments\NUnitSample\XUnit3Example\bin\Debug\net9.0\XUnit3Example.dll" run-date="2025-11-28" run-time="19:10:25" start-rtf="2025-11-28T19:10:25.8223596-05:00" test-framework="xUnit.net v3 3.2.1+a9cfb80929" target-framework=".NETCoreApp,Version=v9.0" errors="0" failed="0" finish-rtf="2025-11-28T19:10:25.9156474-05:00" not-run="0" passed="1" skipped="0" time="0.096" time-rtf="00:00:00.0955747" total="1">
+        <collection name="Test collection for XUnit3Example.UnitTest1 (id: 9a80670184d1db2d84f9626a0691a69e7a1bc8269bd9404c91aff3b1e1deb03b)" id="3df4b797-1953-4ae7-a319-11702b03c556" failed="0" not-run="0" passed="1" skipped="0" time="0.013" time-rtf="00:00:00.0125588" total="1">
+            <test id="6e33fa46-f19d-49c0-9151-ccbaa5fd3857" name="XUnit3Example.UnitTest1.Test1" result="Pass" time="0.0125588" time-rtf="00:00:00.0125588" start-rtf="2025-11-29T00:10:25.8830701+00:00" finish-rtf="2025-11-29T00:10:25.9039940+00:00" type="XUnit3Example.UnitTest1" method="Test1" source-file="C:\dev\code\_Experiments\NUnitSample\XUnit3Example\UnitTest1.cs" source-line="5" />
+        </collection>
+    </assembly>
+</assemblies>

--- a/PublishTestPlanResultsV1/test/testUtil.ts
+++ b/PublishTestPlanResultsV1/test/testUtil.ts
@@ -161,9 +161,11 @@ export function newShallowReference(id : string, name : string) {
   return <ShallowReference>{ id: id, name: name};
 }
 
-export function newTestFrameworkResult(name : string = "Test1", outcome : string = "PASS", properties? : Map<string, string>) : TestFrameworkResult {
+export function newTestFrameworkResult(name : string = "Test1", outcome : string = "PASS", properties? : Map<string, string>, started? : Date, completed? : Date) : TestFrameworkResult {
   let result = new TestFrameworkResult(name, outcome);
   result.duration = 1000;
+  result.startedDate = started;
+  result.completedDate = completed;
   if (properties) {
     properties.forEach((value, key) => {
       result.properties.set(key, value);


### PR DESCRIPTION
Addresses #122 

Note that not all test frameworks record timestamps for test results. When this information is available the started and completed timestamps are recorded on the TestPoint.