### PR TITLE
feat: update testcase automation status

### DIFF
--- a/PublishTestPlanResultsV1/README.md
+++ b/PublishTestPlanResultsV1/README.md
@@ -27,6 +27,7 @@ Publishes test results to your Azure DevOps Test Plan.
     #failTaskOnUnmatchedTestCases: # boolean. Optional
     #dryRun: # boolean. Optional
     #telemetryOptOut: boolean. Optional
+    #updateTestCaseAutomationStatus: #boolean. Optional. 
 ```
 
 ## Inputs
@@ -171,7 +172,14 @@ Enables or disables publishing results to the TestPlan. Useful for evaluating di
 
 `boolean`. Optional.
 
-Enables or disables anonymous data collection. When disabled, an opt-out flag is collected instead. The telemetry payload appears in the debug log.
+Enables or disables anonymous data collection. When enabled, an opt-out flag is collected instead. The telemetry payload appears in the debug log.
+
+### `updateTestCaseAutomationStatus` - Update TestCase Automation status
+
+`boolean`. Optional.
+
+When enabled, the Test Automation Status (`Microsoft.VSTS.TCM.TestAutomationStatus`) field for all matching TestCases will be set to _Automated_. Useful for teams
+that track percentage of _Automated_ versus _Not Automated_ TestCases.
 
 ## Feature Flags
 

--- a/PublishTestPlanResultsV1/README.md
+++ b/PublishTestPlanResultsV1/README.md
@@ -36,7 +36,13 @@ Publishes test results to your Azure DevOps Test Plan.
 
 `string`. Optional
 
-Access Token used to obtain Test Plan details and publish Test Results. Defaults to PAT token of the build agent, `$(System.AccessToken)`
+Access Token used to obtain Test Plan details and publish Test Results. Defaults to PAT token of the build agent, `$(System.AccessToken)`.
+
+Custom PAT tokens must have the following permission scopes:
+
+- Project and Team (read): for accessing Azure DevOps REST APIs
+- Test Management (read & write): for querying TestPlans and updating TestRuns
+- Work Items (read & write): for updating automation status of TestCases
 
 ### `collectionUri` - Azure DevOps Instance
 

--- a/PublishTestPlanResultsV1/TaskParameters.ts
+++ b/PublishTestPlanResultsV1/TaskParameters.ts
@@ -5,6 +5,7 @@ import { TestResultContextParameters } from "./context/TestResultContextParamete
 import { TestFrameworkParameters } from "./framework/TestFrameworkParameters";
 import { TestResultProcessorParameters } from './processing/TestResultProcessorParameters';
 import { TestRunPublisherParameters } from './publishing/TestRunPublisherParameters';
+import { TestRunReporterParameters } from './reporting/TestRunReporterParameters';
 import { TaskParameterHelper } from './services/TaskParameterHelper';
 import { PrivacyLevel, TelemetryPayloadBuilder } from './services/TelemetryPayloadBuilder';
 import { StatusFilterParameters } from './services/StatusFilterParameters';
@@ -170,6 +171,29 @@ class TaskParameters {
     }
     return result;
   }
+
+  /* Fetch parameters used for reporting test automation status */
+  getTestRunReporterParameters() : TestRunReporterParameters {
+    tl.debug("reading TestRunReporterParameters from task inputs.");
+    this.tph.recordStage("getReporterParameters");
+
+    // fetch parameters
+    this.#ensureCredentialsAreSet();
+    const dryRun = this.#getDryRun();
+    const updateTestCaseAutomationStatusInput = this.tph.getBoolInput("updateTestCaseAutomationStatus", /*default*/ false, { recordValue: true, dontRecordDefault: true });
+
+    // only update when opted in and not in dry run
+    const updateTestCaseAutomationStatus = 
+            !dryRun && 
+            updateTestCaseAutomationStatusInput && 
+            FeatureFlags.isFeatureEnabled(FeatureFlag.UpdateTestCaseAutomationStatus);
+
+    // construct parameters
+    var parameters = new TestRunReporterParameters(this.collectionUri!, this.projectName!, this.accessToken!, updateTestCaseAutomationStatus);
+    this.tph.recordStage("reportTestRunDetails");
+
+    return parameters;
+  };
 
   #ensureCredentialsAreSet() {
     if (!this.accessToken) {

--- a/PublishTestPlanResultsV1/Test-ExtensionLocally.ps1
+++ b/PublishTestPlanResultsV1/Test-ExtensionLocally.ps1
@@ -123,6 +123,10 @@ param(
   [AllowEmptyString()]
   [string]$DryRun,
 
+  [Parameter(Mandatory)]
+  [AllowEmptyString()]
+  [string]$UpdateTestCaseAutomationStatus,
+
   [switch]$DebugMode
 
 )

--- a/PublishTestPlanResultsV1/context/TestResultContext.ts
+++ b/PublishTestPlanResultsV1/context/TestResultContext.ts
@@ -87,6 +87,10 @@ export class TestResultContext {
     return [...this.testPoints.values()];
   }
 
+  getTestPoint(id: number): TestPoint | undefined {
+    return this.testPoints.get(id);
+  }
+
   getTestConfig(alias: string) : TestConfiguration {
     if (! this.hasConfig(alias)) {
       throw new Error(`Unrecognized configuration ${alias}.`);

--- a/PublishTestPlanResultsV1/index.ts
+++ b/PublishTestPlanResultsV1/index.ts
@@ -7,6 +7,7 @@ import { TestRunPublisher } from "./publishing/TestRunPublisher";
 import { getLogger } from './services/Logger';
 import * as statusFilter from './services/StatusFilter';
 import TelemetryPublisher from "./telemetry/TelemetryPublisher";
+import { TestRunReporter } from "./reporting/TestRunReporter";
 
 async function run() {
 
@@ -43,6 +44,12 @@ async function run() {
     const publisherParameters = TaskParameters.getPublisherParameters();
     const publisher = await TestRunPublisher.create(publisherParameters);
     await publisher.publishTestRun(testRunData);
+
+    // report results and update automation status
+    logger.info('##[section]Reporting results and updating automation status...');
+    const reporterParameters = TaskParameters.getTestRunReporterParameters();
+    const reporter = await TestRunReporter.create(reporterParameters);
+    await reporter.reportTestResults(context, testRunData);
 
     // finalize task outcome
     logger.info('##[section]Finalizing results...');

--- a/PublishTestPlanResultsV1/reporting/TestRunReporter.ts
+++ b/PublishTestPlanResultsV1/reporting/TestRunReporter.ts
@@ -1,0 +1,94 @@
+import { TestPoint } from "azure-devops-node-api/interfaces/TestInterfaces";
+import { TestResultContext } from "../context/TestResultContext";
+import { TestResultProcessorResult } from "../processing/TestResultProcessor";
+import { AdoWrapper, TestPoint2 } from "../services/AdoWrapper";
+import { ILogger, getLogger } from "../services/Logger";
+import { TestRunReporterParameters } from "./TestRunReporterParameters";
+
+/* The TestRunReporter is responsible for reporting final test results 
+   and updating the automation status of workitems */
+export class TestRunReporter {
+
+    /* create a configured instance of the TestRunReporter */
+    public static async create( parameters : TestRunReporterParameters) : Promise<TestRunReporter> {
+        var ado = await AdoWrapper.createInstance(parameters.collectionUri, parameters.accessToken);
+        var logger = getLogger();
+        var reporter = new TestRunReporter(ado, logger);
+        reporter.updateTestCaseAutomationStatus = parameters.updateTestCaseAutomationStatus;
+        return reporter;
+    }
+
+    private ado: AdoWrapper;
+    private logger: ILogger;
+
+    public updateTestCaseAutomationStatus: boolean;
+
+    constructor(ado : AdoWrapper, logger : ILogger) {
+        this.ado = ado;
+        this.logger = logger;
+        this.updateTestCaseAutomationStatus = false;
+    }
+
+    public async reportTestResults(ctx : TestResultContext, testResults: TestResultProcessorResult) : Promise<void> {
+
+        // if the user has not opted in to update automation status, exit.
+        if (!this.updateTestCaseAutomationStatus) {
+            this.logger.info("Skipping workitem automation status update because 'updateTestCaseAutomationStatus' is false.");
+            return;
+        }
+
+        // if there are no matched test results, exit.
+        if (testResults.matches.size == 0) {
+            this.logger.info("Skipping workitem automation status update because no test cases were matched.");
+            return;
+        }
+
+        // TODO: For reporting purposes
+        // - Calculate total number of test cases in the test plan
+        // - Calculate total number of (unique) test cases in the test plan
+        // - Calculate total number of automated / non-automated test cases
+        
+        // Locate all TestCases to update 
+        this.logger.debug('Locating workitems to update....');
+        var workItemsToUpdate = new Set<number>();
+        for (const testPointId of testResults.matches.keys()) {
+            var testPoint = ctx.getTestPoint(testPointId)! as TestPoint2;
+            let testCaseId = testPoint.testCaseReference?.id;
+            if (testCaseId && !this.isAutomatedTestCase(testPoint)) {
+                workItemsToUpdate.add(parseInt(testCaseId));
+            }
+        }
+        this.logger.debug(`Located ${workItemsToUpdate.size} workitems to update.`);
+
+        // TODO: Locate all TestCases to reset
+
+        this.logger.info("Updating automation status for TestCases...");
+        for (const workItemId of workItemsToUpdate) {
+            this.logger.debug(`Updating automation status for TestCase ${workItemId}...`);
+            await this.ado.updateTestCaseAutomationStatus(workItemId, true);
+        }
+
+        // TODO: Report summary
+        // - Total number of test cases in test plan
+        // - Total number of test cases in test plan (unique)
+        // - Total number of automated test cases in test plan
+        // - Total number of non-automated test cases in test plan
+        // - Total number of test cases updated to automated + percentage change
+        // - Total number of test cases that were already automated (coverage percentage)
+    }
+
+    private isAutomatedTestCase(testPoint : TestPoint) : boolean {
+        try {
+            var automationProperty = testPoint.workItemProperties.find(p => p["Microsoft.VSTS.TCM.AutomationStatus"] !== undefined);
+            if (!automationProperty) {
+                // shouldn't be possible, but if it is, assume not automated
+                this.logger.debug(`No automation status property found for test point ${testPoint.id}. Assuming not automated.`);
+                return false;
+            }
+            return automationProperty["Microsoft.VSTS.TCM.AutomationStatus"] === "Automated";
+        } catch (error) {
+            this.logger.error(`Error checking automation status for test point ${testPoint.id}: ${error}`);
+            return false;
+        }
+    }
+}

--- a/PublishTestPlanResultsV1/reporting/TestRunReporter.ts
+++ b/PublishTestPlanResultsV1/reporting/TestRunReporter.ts
@@ -65,7 +65,7 @@ export class TestRunReporter {
         this.logger.info("Updating automation status for TestCases...");
         for (const workItemId of workItemsToUpdate) {
             this.logger.debug(`Updating automation status for TestCase ${workItemId}...`);
-            await this.ado.updateTestCaseAutomationStatus(workItemId, true);
+            await this.ado.updateTestCaseAutomationStatus(ctx.projectId, workItemId, true);
         }
 
         // TODO: Report summary

--- a/PublishTestPlanResultsV1/reporting/TestRunReporterParameters.ts
+++ b/PublishTestPlanResultsV1/reporting/TestRunReporterParameters.ts
@@ -1,0 +1,13 @@
+export class TestRunReporterParameters {
+    public accessToken: string;
+    public collectionUri: string;
+    public projectName: string;
+    public updateTestCaseAutomationStatus : boolean;
+
+    constructor(collectionUri: string, projectName: string, accessToken: string, updateTestCaseAutomationStatus : boolean) {
+        this.accessToken = accessToken;
+        this.collectionUri = collectionUri;
+        this.projectName = projectName;       
+        this.updateTestCaseAutomationStatus = updateTestCaseAutomationStatus;
+    }
+}

--- a/PublishTestPlanResultsV1/services/AdoWrapper.ts
+++ b/PublishTestPlanResultsV1/services/AdoWrapper.ts
@@ -1,6 +1,7 @@
 
 import * as ado from "azure-devops-node-api";
 import * as Contracts from 'azure-devops-node-api/interfaces/TestInterfaces'
+import * as VssInterfaces from 'azure-devops-node-api/interfaces/common/VSSInterfaces'
 import { ClientApiBase } from "azure-devops-node-api/ClientApiBases";
 import { ICoreApi } from "azure-devops-node-api/CoreApi";
 import { ITestApi } from "azure-devops-node-api/TestApi";
@@ -8,6 +9,7 @@ import { IWorkItemTrackingApi } from "azure-devops-node-api/WorkItemTrackingApi"
 import * as fs from "fs";
 import path from "path";
 import { ILogger, getLogger } from "./Logger";
+import { WorkItem } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces";
 
 interface AdoResponseHeaders {
   "x-ms-continuationtoken"? : string;
@@ -239,6 +241,11 @@ export class AdoWrapper {
     return results;
   }
 
+  async GetWorkItem(workItemId : number) : Promise<WorkItem> {
+    this.logger.debug(`GetWorkItem workItemId:${workItemId}`);
+    return await this.workItemApi.getWorkItem(workItemId);
+  }
+
   /**
    * Updates the outcomes for TestCaseResult for a given TestRun
    * 
@@ -276,10 +283,25 @@ export class AdoWrapper {
     return await this.testApi.updateTestRun(updateModel, projectId, testRun.id);
   }
 
-  async updateTestCaseAutomationStatus(workItemId : number, automationStatus : boolean) : Promise<void> {
+  /**
+   * Updates the Microsoft.VSTS.TCM.AutomationStatus field for a TestCase workitem
+   * 
+   * @param projectId project id or identifer
+   * @param workItemId workitem id
+   * @param automationStatus boolean to mark the test as automated / not automated
+   */
+  async updateTestCaseAutomationStatus(projectId : string, workItemId : number, automationStatus : boolean) : Promise<void> {
     this.logger.debug(`updating TestCaseAutomationStatus for workItemId:${workItemId} automationStatus:${automationStatus}`);
-    // Implementation for updating the automation status of a work item
-    throw new Error("Not implemented yet");
+    
+    const patch : VssInterfaces.JsonPatchOperation[] = [
+      {
+        op: VssInterfaces.Operation.Add,
+        path: "/fields/Microsoft.VSTS.TCM.AutomationStatus",
+        value: automationStatus ? "Automated" : "Not Automated"
+      }
+    ];
+
+    await this.workItemApi.updateWorkItem( [] , patch, workItemId, projectId, false, true, false);
   }
 
   private async fetchWithPagination<T>(api : ClientApiBase, baseUrl : string, responseType : any) : Promise<T[]> {

--- a/PublishTestPlanResultsV1/services/AdoWrapper.ts
+++ b/PublishTestPlanResultsV1/services/AdoWrapper.ts
@@ -4,6 +4,7 @@ import * as Contracts from 'azure-devops-node-api/interfaces/TestInterfaces'
 import { ClientApiBase } from "azure-devops-node-api/ClientApiBases";
 import { ICoreApi } from "azure-devops-node-api/CoreApi";
 import { ITestApi } from "azure-devops-node-api/TestApi";
+import { IWorkItemTrackingApi } from "azure-devops-node-api/WorkItemTrackingApi";
 import * as fs from "fs";
 import path from "path";
 import { ILogger, getLogger } from "./Logger";
@@ -28,17 +29,20 @@ export class AdoWrapper {
     let connection = new ado.WebApi(server, handler);
     let coreApi = await connection.getCoreApi();
     let testApi = await connection.getTestApi();
+    let workItemApi = await connection.getWorkItemTrackingApi();
     let logger = getLogger();
-    return new AdoWrapper(coreApi, testApi, logger);
+    return new AdoWrapper(coreApi, testApi, workItemApi, logger);
   }
 
   coreApi : ICoreApi;
   testApi : ITestApi;
+  workItemApi : IWorkItemTrackingApi;
   logger : ILogger;
   
-  constructor(coreApi : ICoreApi, testApi : ITestApi, logger : ILogger) {
+  constructor(coreApi : ICoreApi, testApi : ITestApi, workItemApi : IWorkItemTrackingApi, logger : ILogger) {
     this.coreApi = coreApi;
     this.testApi = testApi;
+    this.workItemApi = workItemApi;
     this.logger = logger;
   }
 
@@ -270,6 +274,12 @@ export class AdoWrapper {
       state: testRun.state 
     };
     return await this.testApi.updateTestRun(updateModel, projectId, testRun.id);
+  }
+
+  async updateTestCaseAutomationStatus(workItemId : number, automationStatus : boolean) : Promise<void> {
+    this.logger.debug(`updating TestCaseAutomationStatus for workItemId:${workItemId} automationStatus:${automationStatus}`);
+    // Implementation for updating the automation status of a work item
+    throw new Error("Not implemented yet");
   }
 
   private async fetchWithPagination<T>(api : ClientApiBase, baseUrl : string, responseType : any) : Promise<T[]> {

--- a/PublishTestPlanResultsV1/services/FeatureFlags.ts
+++ b/PublishTestPlanResultsV1/services/FeatureFlags.ts
@@ -3,6 +3,7 @@ import { getLogger, ILogger } from "./Logger";
 export class FeatureFlag {
   static DisplayTelemetry : string = "displaytelemetry";
   static DisplayTelemetryErrors : string = "displaytelemetryerrors";
+  static UpdateTestCaseAutomationStatus : string = "updatetestcaseautomationstatus";
 }
 
 export class FeatureFlags {

--- a/PublishTestPlanResultsV1/task.json
+++ b/PublishTestPlanResultsV1/task.json
@@ -225,6 +225,15 @@
             "groupName": "advanced",
             "defaultValue": "false",
             "helpMarkDown": "Opt out of anonymous usage data collection to help improve this extension."
+        },
+        {
+            "name": "updateTestCaseAutomationStatus",
+            "type": "boolean",
+            "required": false,
+            "label": "Update Test Case Automation Status",
+            "groupName": "advanced",
+            "defaultValue": "false",
+            "helpMarkDown": "When set to true, the task will update the Automation Status field of the TestCase for all matched results."
         }
     ],
     "minimumAgentVersion": "2.209.0",

--- a/PublishTestPlanResultsV1/task.json
+++ b/PublishTestPlanResultsV1/task.json
@@ -230,7 +230,7 @@
             "name": "updateTestCaseAutomationStatus",
             "type": "boolean",
             "required": false,
-            "label": "Update Test Case Automation Status",
+            "label": "Update TestCase Automation Status",
             "groupName": "advanced",
             "defaultValue": "false",
             "helpMarkDown": "When set to true, the task will update the Automation Status field of the TestCase for all matched results."

--- a/PublishTestPlanResultsV1/test/AdoWrapper.specs.ts
+++ b/PublishTestPlanResultsV1/test/AdoWrapper.specs.ts
@@ -119,6 +119,42 @@ describe("AdoWrapper", () => {
       // assert
       expect(result.length).greaterThan(0);
     })
+
+    it("Should retrieve work item details for a test case", async function () {
+      // arrange
+      this.timeout(10000);
+      var testPoints = await subject.getTestPointsForSuite(projectId, planId, rootSuite, true);
+      var workItemId = testPoints[0].testCaseReference.id!;
+
+      // act
+      var workItem = await subject.GetWorkItem(parseInt(workItemId));
+
+      // assert
+      expect(workItem).not.undefined;
+      expect(workItem.fields).not.undefined;
+      expect(workItem.fields!["System.WorkItemType"]).eq("Test Case");
+      expect(workItem.fields!["Microsoft.VSTS.TCM.AutomationStatus"]).not.undefined;
+    })
+
+    it("Should update automation status for a test case work item", async function () {
+      // arrange
+      this.timeout(20000);
+      var testPoints = await subject.getTestPointsForSuite(projectId, planId, rootSuite, true);
+      var workItemId = testPoints[0].testCaseReference.id!;
+      let workItem = await subject.GetWorkItem(parseInt(workItemId));
+      var automationStatus = workItem.fields!["Microsoft.VSTS.TCM.AutomationStatus"] as string;
+
+      // act
+      await subject.updateTestCaseAutomationStatus(projectId, parseInt(workItemId), automationStatus != "Automated");
+      workItem = await subject.GetWorkItem(parseInt(workItemId));
+      var updatedAutomationStatus = workItem.fields!["Microsoft.VSTS.TCM.AutomationStatus"] as string;
+
+      // assert
+      expect(updatedAutomationStatus).eq(automationStatus != "Automated" ? "Automated" : "Not Automated");
+
+      // reset the automation status to the original value
+      await subject.updateTestCaseAutomationStatus(projectId, parseInt(workItemId), automationStatus == "Automated");
+    })
   })  
 
   // unit test / stub out rest get
@@ -341,7 +377,6 @@ describe("AdoWrapper", () => {
     })
 
   })
-
 
   function stubGetRequestWithContinuationToken(nameFormat : string) {
     const getRequestStub = sinon.stub(subject.testApi.rest, "get");

--- a/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
+++ b/PublishTestPlanResultsV1/test/TaskParameters.specs.ts
@@ -1542,6 +1542,97 @@ describe('TaskParameters', () => {
     });
   });
 
+  context('TestRunReporterParameters', () => {
+
+    beforeEach(() => {
+      // TODO: remove
+      util.setFeatureFlag(FeatureFlag.UpdateTestCaseAutomationStatus, "true");
+    });
+
+    it('Should record begin and end of testrun reporting stage in telemetry', () => {
+      // arrange
+      // mock out the tph to spy on recordStage
+      let recordedStages: string[] = [];
+      subject.tph.recordStage = (stage: string) => {
+        recordedStages.push(stage);
+      };
+      util.loadData();
+
+      // act
+      subject.getTestRunReporterParameters();
+
+      // assert
+      expect(recordedStages.length).to.eq(2);
+      expect(recordedStages[0]).to.eq("getReporterParameters");
+      expect(recordedStages[1]).to.eq("reportTestRunDetails");
+    });
+
+    context('user supplied values', () => {
+
+      it('Should override updateTestCaseAutomationStatus when dryrun is specified', () => {
+        // arrange
+        util.setInput("dryRun", "true");
+        util.setInput("updateTestCaseAutomationStatus", "true");
+        util.loadData();
+
+        // act
+        var parameters = subject.getTestRunReporterParameters();
+        
+        // assert
+        expect(parameters.updateTestCaseAutomationStatus).to.be.false;
+      });
+
+      it('Should recognize when updateTestCaseAutomationStatus is specified', () => {
+        // arrange
+        util.setInput("updateTestCaseAutomationStatus", "true");
+        util.loadData();
+
+        // act
+        var parameters = subject.getTestRunReporterParameters();
+
+        // assert
+        expect(parameters.updateTestCaseAutomationStatus).to.be.true;
+      });
+
+      it('Should record updateTestCaseAutomationStatus in telemetry when value is provided', () => {
+        // arrange
+        util.setInput("updateTestCaseAutomationStatus", "true");
+        util.loadData();
+
+        // act
+        var parameters = subject.getTestRunReporterParameters();
+
+        // assert
+        let telemetry = subject.getTelemetryParameters().payload;
+        expect(telemetry.updateTestCaseAutomationStatus).to.be.true;
+      });
+
+    });
+
+    context('default values', () => {
+
+      it('Should default updateTestCaseAutomationStatus to false', () => {
+        // arrange
+        util.loadData();
+        // act
+        var parameters = subject.getTestRunReporterParameters();
+        
+        // assert
+        expect(parameters.updateTestCaseAutomationStatus).to.be.false;
+      });
+
+      it('Should include default values', () => {
+        // act
+        var parameters = subject.getTestRunReporterParameters();
+
+        // assert
+        expect(parameters.collectionUri).to.eq(process.env.SYSTEM_COLLECTIONURI as string);
+        expect(parameters.accessToken).to.eq(process.env.SYSTEM_ACCESSTOKEN as string);
+        expect(parameters.projectName).to.eq(process.env.SYSTEM_TEAMPROJECT as string);
+      })
+    });
+  });
+
   context('StatusFilterParameters', () => {
 
     context('default values', () => {

--- a/PublishTestPlanResultsV1/test/TestRunReporter.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestRunReporter.specs.ts
@@ -1,0 +1,156 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { AdoWrapper, TestPoint2 } from '../services/AdoWrapper';
+import { TestRunReporter } from '../reporting/TestRunReporter';
+import { ILogger, NullLogger } from "../services/Logger";
+import { TestResultContext } from '../context/TestResultContext';
+import { TestResultProcessorResult } from '../processing/TestResultProcessor';
+import { newTestFrameworkResult, newTestPoint } from './testUtil';
+
+describe('TestRunReporter', () => {
+
+    var subject : TestRunReporter;
+
+    // dependencies
+    var ado : sinon.SinonStubbedInstance<AdoWrapper>;
+    var loggerStub : sinon.SinonStubbedInstance<ILogger>;
+
+    // data
+    var ctx : TestResultContext;
+    var testResults : TestResultProcessorResult;
+
+    beforeEach(() => {
+        ado = sinon.createStubInstance(AdoWrapper);
+        loggerStub = sinon.createStubInstance<ILogger>(NullLogger);
+        subject = new TestRunReporter(ado as unknown as AdoWrapper, loggerStub as ILogger);
+
+        ctx = new TestResultContext("projectId", "projectName", {} as any, loggerStub as ILogger);
+        testResults = new TestResultProcessorResult("projectId", {} as any);
+    });
+
+    context('updateTestCaseAutomationStatus is false', () => {
+
+        beforeEach(() => {
+            subject.updateTestCaseAutomationStatus = false;
+        });
+
+        it('Should not update workitems when updateTestCaseAutomationStatus is false', async () => {
+            // arrange
+
+            // act
+            await subject.reportTestResults(ctx, testResults);
+
+            // assert
+            sinon.assert.notCalled(ado.updateTestCaseAutomationStatus);
+        });
+
+        it('Should log that automation status update is being skipped when updateTestCaseAutomationStatus is false', async () => {
+            // arrange
+
+            // act
+            await subject.reportTestResults(ctx, testResults);
+
+            // assert
+            sinon.assert.calledWith(loggerStub.info, sinon.match("Skipping workitem automation status update because 'updateTestCaseAutomationStatus' is false."));
+        });
+    });
+
+    context('updateTestCaseAutomationStatus is true', () => {
+
+        beforeEach(() => {
+            subject.updateTestCaseAutomationStatus = true;
+        })
+
+        it('Should not update workitems when no test cases were matched', async () => {
+            // arrange
+
+            // act
+            await subject.reportTestResults(ctx, testResults);
+
+            // assert
+            sinon.assert.notCalled(ado.updateTestCaseAutomationStatus);
+        });
+
+        it('Should log that no test cases were matched', async () => {
+            // arrange
+
+            // act
+            await subject.reportTestResults(ctx, testResults);
+
+            // assert
+            sinon.assert.calledWith(loggerStub.info, sinon.match("Skipping workitem automation status update because no test cases were matched."));
+        });
+
+        context('test cases were matched', () => {
+
+            var testPoint1 : TestPoint2;
+            var testPoint2 : TestPoint2;
+            var testCase1 : string;
+            var testCase2 : string;
+
+            beforeEach(() => {
+
+                // add non automated test points to the test plan
+                testCase1 = "1";
+                testCase2 = "2";
+                testPoint1 = newTestPoint(10001, "Test 1", "config1", testCase1);
+                testPoint1.workItemProperties = [{ "Microsoft.VSTS.TCM.AutomationStatus": "NotAutomated" }];
+                testPoint2 = newTestPoint(10002, "Test 2", "config2", testCase2);
+                testPoint2.workItemProperties = [
+                    { "Microsoft.VSTS.TCM.AutomatedTestName": "namespace.class.methodname" },
+                    { "Microsoft.VSTS.TCM.AutomationStatus": "NotAutomated" }
+                ];
+
+                ctx.addTestPoint(testPoint1);
+                ctx.addTestPoint(testPoint2);
+
+                // add matches in the test results
+                testResults.matches.set(testPoint1.id, newTestFrameworkResult("Test 1", "PASS"));
+                testResults.matches.set(testPoint2.id, newTestFrameworkResult("Test 2", "PASS"));
+                
+            });
+
+            it('Should log that it found test cases to update', async () => {
+                // arrange (use defaults above)
+
+                // act
+                await subject.reportTestResults(ctx, testResults);
+
+                // assert
+                sinon.assert.calledWith(loggerStub.debug, sinon.match(`Located 2 workitems to update.`));
+            });
+
+            it('Should update workitems that are not automated', async () => {
+                // arrange (use defaults above)
+
+                // act
+                await subject.reportTestResults(ctx, testResults);
+
+                // assert
+                sinon.assert.calledTwice(ado.updateTestCaseAutomationStatus);
+                sinon.assert.calledWithExactly(ado.updateTestCaseAutomationStatus, 
+                    parseInt(testCase1), true
+                );
+                sinon.assert.calledWithExactly(ado.updateTestCaseAutomationStatus, 
+                    parseInt(testCase2), true
+                );
+            });
+
+            it('Should not update workitems that are already automated', async () => {
+                // arrange
+                testPoint1.workItemProperties = [{ "Microsoft.VSTS.TCM.AutomationStatus": "Automated" }];
+                testPoint2.workItemProperties = [{ "Microsoft.VSTS.TCM.AutomationStatus": "Automated" }];
+
+                // act
+                await subject.reportTestResults(ctx, testResults);
+
+                // assert
+                sinon.assert.notCalled(ado.updateTestCaseAutomationStatus);
+            });
+        })
+    });
+
+    
+
+})

--- a/PublishTestPlanResultsV1/test/TestRunReporter.specs.ts
+++ b/PublishTestPlanResultsV1/test/TestRunReporter.specs.ts
@@ -130,10 +130,10 @@ describe('TestRunReporter', () => {
                 // assert
                 sinon.assert.calledTwice(ado.updateTestCaseAutomationStatus);
                 sinon.assert.calledWithExactly(ado.updateTestCaseAutomationStatus, 
-                    parseInt(testCase1), true
+                    ctx.projectId, parseInt(testCase1), true
                 );
                 sinon.assert.calledWithExactly(ado.updateTestCaseAutomationStatus, 
-                    parseInt(testCase2), true
+                    ctx.projectId,parseInt(testCase2), true
                 );
             });
 

--- a/devops/pipelines/marketplace-extension/pipeline.yml
+++ b/devops/pipelines/marketplace-extension/pipeline.yml
@@ -15,6 +15,13 @@ parameters:
   default: false
 
 variables:
+# group contains:
+#  - AppInsightsConnectionString
+#  - ExtensionId
+#  - ExtensionName
+#  - MarketPlaceServiceConnection (GUID)
+#  - PublisherId
+#  - TestPlanPAT
 - group: pipeline-extension-settings
 - name: workingDir
   value: $(Build.SourcesDirectory)/PublishTestPlanResultsV1

--- a/devops/pipelines/marketplace-extension/regression-test.yml
+++ b/devops/pipelines/marketplace-extension/regression-test.yml
@@ -52,7 +52,13 @@ parameters:
     testplan: 'Plan w Duplicates and TestOutcome Setting Enabled'
     expectedResults:
       - outcome: Passed
-        count: 2        
+        count: 2
+  - name: UpdateTestCaseAutomationStatus
+    format: nunit
+    testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/NUnitExample/TestResults/TestResults.xml'
+    featureFlags: 'UpdateTestCaseAutomationStatus'
+    accessToken: $(System.AccessToken)
+    updateTestCaseAutomationStatus: true
 
 steps:
 - pwsh: |
@@ -91,7 +97,7 @@ steps:
       arguments: >
         -CollectionUri $(System.CollectionUri)
         -ProjectName '${{ iif( ne(test.projectName,''), test.projectName, 'Test Plan Extension' ) }}'
-        -AccessToken $(System.AccessToken)
+        -AccessToken '${{ iif (ne(test.accessToken,''), test.accessToken, '$(System.AccessToken)' ) }}'
         -TestResultFormat ${{ test.format }}
         -TestResultFiles ${{ test.testResultsFile }}
         -TestPlan '${{ iif( ne(test.testPlan,''), test.testPlan, 'Primary Test Plan' ) }}'
@@ -110,8 +116,8 @@ steps:
         -failTaskOnMissingResultsFile ''
         -failTaskOnMissingTests ''
         -failTaskOnUnmatchedTestCases ''
-        -featureFlags '${{ iif(ne(test.featureFlags,''), test.featureFlags, 'DisplayTelemetry,DisplayTelemetryErrors,UpdateTestCaseAutomationStatus') }}'
-        -updateTestCaseAutomationStatus 'true'
+        -featureFlags '${{ iif(ne(test.featureFlags,''), test.featureFlags, 'DisplayTelemetry,DisplayTelemetryErrors') }}'
+        -updateTestCaseAutomationStatus '${{ iif(ne(test.updateTestCaseAutomationStatus,''), test.updateTestCaseAutomationStatus, 'false') }}'
         -DryRun ''
 
   - ${{ if ne(test.expectedResults, '') }}:

--- a/devops/pipelines/marketplace-extension/regression-test.yml
+++ b/devops/pipelines/marketplace-extension/regression-test.yml
@@ -110,7 +110,8 @@ steps:
         -failTaskOnMissingResultsFile ''
         -failTaskOnMissingTests ''
         -failTaskOnUnmatchedTestCases ''
-        -featureFlags '${{ iif(ne(test.featureFlags,''), test.featureFlags, 'DisplayTelemetry,DisplayTelemetryErrors') }}'
+        -featureFlags '${{ iif(ne(test.featureFlags,''), test.featureFlags, 'DisplayTelemetry,DisplayTelemetryErrors,UpdateTestCaseAutomationStatus') }}'
+        -updateTestCaseAutomationStatus 'true'
         -DryRun ''
 
   - ${{ if ne(test.expectedResults, '') }}:

--- a/devops/pipelines/marketplace-extension/regression-test.yml
+++ b/devops/pipelines/marketplace-extension/regression-test.yml
@@ -57,7 +57,7 @@ parameters:
     format: nunit
     testResultsFile: '$(Build.SourcesDirectory)/examples/dotnet/NUnitExample/TestResults/TestResults.xml'
     featureFlags: 'UpdateTestCaseAutomationStatus'
-    accessToken: $(System.AccessToken)
+    accessToken: $(TestPlanPAT)
     updateTestCaseAutomationStatus: true
 
 steps:

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -14,6 +14,7 @@
     "vso.project",
     "vso.test",
     "vso.test_write"
+    //,"vso.work_write" // can't set automation status directly
   ],
   "description": "Updates Azure DevOps Test Plans using xUnit, jUnit and other test result formats",
   "public": false,


### PR DESCRIPTION
This PR introduces new functionality for #57 

It introduces a new task option `updateTestCaseAutomationStatus: true` and requires feature flag `PUBLISHTESTPLANRESULTS_UPDATETESTCASEAUTOMATIONSTATUS`

Note that this experimental feature will be a breaking change that requires new permission `vso.work_write`.  

To use this feature:
- add an environment variable: `PUBLISHTESTPLANRESULTS_UPDATETESTCASEAUTOMATIONSTATUS`
- add `updateTestCaseAutomationStatus: true` to the task inputs
- add `accessToken` to the task inputs with the following permissions:
  - Project and Team (read)
  - Test Management (read & write)
  - Work Items (read & write)
